### PR TITLE
docs: documentar divergencias arquitectonicas criticas con LightRAG o…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,22 +81,52 @@ Inspirada en [LightRAG (EMNLP 2025)](https://arxiv.org/abs/2410.05779).
 
 **Fallback**: sin igraph o sin LLM → degrada a SimpleVectorRetriever puro.
 
-**Alineacion con original (DAM-1 a DAM-8)**: Entity VDB, Relationship VDB, edge weights (log1p), gleaning, BFS 1-hop weighted, graph_primary mode, contexto estructurado, co-occurrence bridging, LLM description synthesis — todo implementado.
+**Alineacion con original (DAM-1 a DAM-8)**: Entity VDB, Relationship VDB, edge weights (log1p), gleaning, BFS 1-hop weighted, graph_primary mode, co-occurrence bridging, LLM description synthesis — todo implementado.
+
+**Divergencia arquitectonica critica**: pese a lo anterior, el pipeline de retrieval+generacion **no replica la arquitectura del paper**. La indexacion es fiel, pero la forma en que se consumen los resultados del KG difiere fundamentalmente (ver seccion siguiente).
 
 ## Divergencias con el paper original — evaluacion de criticidad
 
-Diferencias restantes entre esta implementacion y el [LightRAG original (EMNLP 2025)](https://arxiv.org/abs/2410.05779).
+Diferencias entre esta implementacion y el [LightRAG original (HKUDS/LightRAG, EMNLP 2025)](https://arxiv.org/abs/2410.05779). Validadas empiricamente en F.5 (125q, 4000 docs, seed=42): LIGHT_RAG produjo metricas de retrieval **identicas** a SIMPLE_VECTOR, confirmando que las divergencias arquitectonicas anulan la contribucion del KG.
+
+### Divergencias arquitectonicas (descubiertas en F.5)
+
+| # | Divergencia | Criticidad | Detalle |
+|---|---|---|---|
+| 4 | **Contexto aplanado a ranking de docs** — el original presenta entidades, relaciones y chunks como **secciones separadas** en el prompt del LLM; aqui todo se aplana a un ranking unico de doc_ids | **9/10** | El LLM del original recibe contexto estructurado (`"Knowledge Graph Data:"` + `"Document Chunks:"`) con presupuesto de tokens por tipo. Aqui el KG solo sirve como puntero a documentos, perdiendo las descripciones de entidades/relaciones. `retrieval_executor.py:format_structured_context()` intenta mitigar esto pero opera post-reranker, sobre docs ya filtrados. |
+| 5 | **RRF fusiona KG + vector en un ranking unico** — el original no fusiona, presenta ambos canales por separado al LLM | **8/10** | El original no usa RRF ni fusion lineal. Entidades y relaciones son secciones independientes con token budgets propios (`max_entity_tokens`, `max_relation_tokens`). CH_LIRAG convierte todo a scores de documentos y fusiona via RRF (`core.py:reciprocal_rank_fusion()`), descartando la granularidad entity/relation. |
+| 6 | **Reranker post-fusion anula senal del grafo** — el original no usa reranker (adicion post-publicacion al repo) | **8/10** | El `CrossEncoderReranker` se aplica incondicionalmente a ambas estrategias (`retrieval_executor.py:100-146`). Evalua similitud query↔doc en aislamiento — los docs multi-hop que el KG aporta (indirectamente relevantes) puntuan bajo y caen del top-N. En F.5, el reranker colapso el ranking LIGHT_RAG al mismo top-20 que SIMPLE_VECTOR en las 125 queries. |
+| 7 | **Sin token budgets separados por tipo** — el original asigna presupuesto independiente a entidades, relaciones y chunks | **5/10** | Un unico `max_context_chars` se aplica al contexto concatenado. Las descripciones de entidades/relaciones compiten con los chunks por el mismo espacio, en vez de tener presupuesto garantizado. |
+
+### Divergencias menores (preexistentes)
 
 | # | Divergencia | Criticidad | Estado |
 |---|---|---|---|
-| 1 | Sin validacion empirica (F.5 pendiente) | **6/10** | Requiere infra NIM + MinIO. Prerequisito para validar todo lo demas. |
-| 2 | Sin LLM synthesis en fusion final de contexto | **5/10** | El paper sintetiza vector + graph antes de generar. Aqui se concatena. RRF mitiga parcialmente. |
-| 3 | Entity cap 100K | **3/10** | Eviction mejorada con score compuesto, pero cap se mantiene. Para HotpotQA (66K docs) no se alcanza. |
+| 2 | Sin LLM synthesis en fusion final de contexto | **5/10** | Subsumida por #4/#5: la fusion synthesis del paper opera sobre el contexto estructurado (secciones separadas). Sin ese contexto, synthesis no resolveria el problema de fondo. |
+| 3 | Entity cap 100K | **3/10** | Eviction mejorada con score compuesto. Para HotpotQA (66K docs, ~24K entidades) no se alcanza. |
 
-**Resueltas:**
+### Resueltas (indexacion)
+
 - ~~DAM-4 (7/10)~~: LLM synthesis para descripciones → `KG_DESCRIPTION_SYNTHESIS=true` (A5.1)
 - ~~Grafo fragmentado (3/10)~~: Co-occurrence bridging (DTm-73)
 - ~~BFS scoring uniforme (3/10)~~: Edge weights via `log(1 + n_docs)` (DTm-72)
+
+### Resultado F.5 (validacion empirica)
+
+Runs ejecutadas: SIMPLE_VECTOR y LIGHT_RAG hybrid (125q, 4000 docs, DEV_MODE, seed=42, reranker ON).
+
+| Metrica | SIMPLE_VECTOR | LIGHT_RAG | Delta |
+|---|---|---|---|
+| Hit@5 | 1.000 | 1.000 | 0 |
+| MRR | 0.992 | 0.992 | 0 |
+| Recall@5 | 0.968 | 0.968 | 0 |
+| Recall@20 | 0.988 | 0.988 | 0 |
+| Avg gen score | 0.7764 | 0.7877 | +0.011 (ruido LLM) |
+| Tiempo total | 194.7s | 9002.1s | ×46 |
+
+**Todas las metricas de retrieval son identicas query por query.** El KG aporto ~49 docs exclusivos por query, pero el reranker colapso el ranking final al mismo top-20 que SIMPLE_VECTOR. Las 10 diferencias en generacion son no-determinismo del LLM (mismo contexto, distinta respuesta).
+
+**Conclusion**: la indexacion KG funciona correctamente (23K entidades, 55K relaciones, 32K co-occurrence edges), pero las divergencias #4/#5/#6 impiden que su senal llegue al LLM.
 
 ## Deuda tecnica vigente
 
@@ -108,7 +138,7 @@ Diferencias restantes entre esta implementacion y el [LightRAG original (EMNLP 2
 | 4 | LLM Judge puede devolver scores por defecto | **MEDIO-BAJO** | `metrics.py:_extract_score_fallback()` intenta 4 regex patterns; si todos fallan retorna 0.5 — sesga metricas silenciosamente. Se logea a WARNING | Post-run, buscar `"Score extraction fallback"` en logs y contar ocurrencias |
 | 5 | Context window fallback silencioso | **BAJO** | `embedding_service.py:resolve_max_context_chars()` — si `GET /v1/models` falla, usa fallback de 4000 chars (~1000 tokens). Puede truncar docs importantes. Se logea WARNING | Configurar `GENERATION_MAX_CONTEXT_CHARS` explicitamente en `.env` |
 
-La divergencia #2 (fusion synthesis) sigue pendiente pero requiere decision de coste/latencia post-F.5.
+Las divergencias arquitectonicas #4/#5/#6 son la causa raiz de que LIGHT_RAG no aporte valor. Ver seccion "Divergencias con el paper original".
 
 ## Bare excepts aceptados (no criticos)
 
@@ -144,16 +174,17 @@ Estos `except Exception as e:` logean el error pero no lo re-lanzan. Aceptable p
 
 ## Proximos pasos
 
-### Run comparativo F.5 (requiere infra NIM + MinIO)
+### Alinear pipeline LIGHT_RAG con el paper original
 
-| Tarea | Descripcion |
-|---|---|
-| F.5a | Run SIMPLE_VECTOR baseline: 50q, 3500 docs, DEV_MODE, seed=42 |
-| F.5b | Run LIGHT_RAG hybrid: misma config (con `KG_DESCRIPTION_SYNTHESIS=true`) |
-| F.5c | Run LIGHT_RAG graph_primary |
-| F.5d | Analisis comparativo: MRR, Hit@5, Recall |
+F.5 demostro que la indexacion KG funciona pero el pipeline de consumo no. Acciones ordenadas por impacto:
 
-**Criterio de exito:** LIGHT_RAG MRR > 0.80 (vs 0.52 pre-VDBs). Si no, evaluar divergencia #2 (fusion synthesis).
+| Prioridad | Tarea | Divergencia | Descripcion |
+|---|---|---|---|
+| **P0** | Contexto estructurado al LLM | #4 | Pasar entidades + relaciones + chunks como secciones separadas en el prompt, con token budgets independientes. Requiere refactor de `retrieval_executor.py:format_structured_context()` y `generation_executor.py` |
+| **P0** | Eliminar RRF entre KG y vector | #5 | No fusionar en un ranking unico. Cada canal (entidades, relaciones, vector chunks) mantiene su propio conjunto de resultados. El LLM decide que es relevante |
+| **P1** | Desactivar reranker para LIGHT_RAG | #6 | Flag `RERANKER_SKIP_FOR_LIGHT_RAG` o desactivar incondicionalmente cuando strategy=LIGHT_RAG. El cross-encoder single-hop es incompatible con retrieval multi-hop |
+| **P2** | Token budgets por tipo | #7 | `max_entity_tokens`, `max_relation_tokens`, `max_chunk_tokens` en config, en vez de un unico `max_context_chars` |
+| **P3** | Re-run F.5 post-refactor | — | Repetir comparativa SIMPLE_VECTOR vs LIGHT_RAG con pipeline alineado |
 
 ### Limitaciones conocidas (no accionables)
 


### PR DESCRIPTION
…riginal

F.5 (125q, 4000 docs) demostro que LIGHT_RAG produce metricas de retrieval identicas a SIMPLE_VECTOR. Causa raiz: 4 divergencias arquitectonicas no documentadas previamente:

- #4 (9/10): contexto aplanado a ranking de docs en vez de secciones separadas (entities/relations/chunks) como hace el paper original
- #5 (8/10): RRF fusiona KG + vector en ranking unico; el original no fusiona
- #6 (8/10): reranker cross-encoder post-fusion anula senal multi-hop del KG
- #7 (5/10): sin token budgets separados por tipo de contexto

Reescribe seccion de divergencias con evidencia empirica F.5, reclasifica divergencia #2 como subsumida por #4/#5, y reemplaza proximos pasos F.5 por plan de alineacion arquitectonica con el paper.

https://claude.ai/code/session_01S9CVw5wvugum3KaADYZ9LM