### PR TITLE
fix: clean stale RRF refs and dead dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ RETRIEVAL_K=20
 # Knowledge Graph (solo LIGHT_RAG)
 LIGHTRAG_MODE=hybrid                  # hybrid | local | global | naive
 KG_MAX_HOPS=1                         # Profundidad BFS (1-hop como el original)
-KG_GRAPH_WEIGHT=0.3                   # Peso graph en fusion (vector = 0.7)
-KG_FUSION_METHOD=rrf                  # rrf (default) o linear
 KG_EXTRACTION_MAX_TOKENS=4096         # Max tokens para triplet extraction
 KG_BATCH_DOCS_PER_CALL=5             # Docs por LLM call en batch
 KG_MAX_ENTITIES=0                     # Cap entidades (0 = default interno 100K)

--- a/requirements.lock
+++ b/requirements.lock
@@ -27,27 +27,9 @@ jmespath==1.1.0
 # --- Utilidades ---
 python-dotenv==1.2.2
 
-# --- NER (Entity Cross-Linking, HYBRID_PLUS) ---
-spacy==3.8.11
-spacy-legacy==3.0.12
-spacy-loggers==1.0.5
-thinc==8.3.10
-blis==1.3.3
-cymem==2.0.13
-murmurhash==1.0.15
-preshed==3.0.12
-srsly==2.5.2
-wasabi==1.1.3
-weasel==0.4.3
-catalogue==2.0.10
-confection==0.1.5
-
 # --- Knowledge Graph (LIGHT_RAG) ---
-networkx==3.6.1
-
-# --- Hybrid Retrieval: BM25 ---
-tantivy==0.25.1
-rank-bm25==0.2.2
+python-igraph==0.11.8
+snowballstemmer==3.0.1
 
 # --- Testing ---
 pytest==9.0.2

--- a/sandbox_mteb/config.py
+++ b/sandbox_mteb/config.py
@@ -208,10 +208,9 @@ class MTEBConfig:
         from shared.retrieval.core import RetrievalStrategy
         if self.retrieval.strategy == RetrievalStrategy.LIGHT_RAG:
             lines.extend([
-                f"  KG weights: graph={self.retrieval.kg_graph_weight}, vector={self.retrieval.kg_vector_weight}",
-                f"  KG fusion:  {self.retrieval.kg_fusion_method} (rrf_k={self.retrieval.kg_rrf_k})",
+                f"  KG mode:    {self.retrieval.lightrag_mode}",
                 f"  KG tokens:  extraction={self.retrieval.kg_extraction_max_tokens}, keyword={self.retrieval.kg_keyword_max_tokens}",
-                f"  KG batch:   {self.retrieval.kg_batch_docs_per_call} docs/call, overfetch={self.retrieval.kg_graph_overfetch_factor}x",
+                f"  KG batch:   {self.retrieval.kg_batch_docs_per_call} docs/call",
                 f"  WARNING:    LIGHT_RAG requiere ~1 llamada LLM por documento "
                 f"para construir el knowledge graph (concurrencia={self.infra.nim_max_concurrent})",
             ])

--- a/sandbox_mteb/env.example
+++ b/sandbox_mteb/env.example
@@ -129,22 +129,18 @@ MINIO_SECRET_KEY=minio123
 MINIO_BUCKET_NAME=lakehouse
 S3_DATASETS_PREFIX=datasets/evaluation
 
-# Max docs anadidos via graph expansion post-retrieval (LIGHT_RAG).
-# 0 = sin limite. Default=30.
-MAX_GRAPH_EXPANSION=30
-
 # =========================================================================
 # KNOWLEDGE GRAPH (solo LIGHT_RAG)
 # =========================================================================
 # Requiere: pip install python-igraph snowballstemmer
 # Sin igraph o sin LLM service, LIGHT_RAG degrada a SimpleVector puro.
 
-# Modo de retrieval LightRAG (F.4/DTm-79):
-#   hybrid        — entity VDB + relationship VDB + vector, fusion RRF (default)
-#   graph_primary — grafo traza source docs, vector como fallback (DAM-3)
-#   local         — solo entity VDB + BFS (low-level)
-#   global        — solo relationship VDB (high-level)
-#   naive         — solo vector search, sin KG (= SIMPLE_VECTOR)
+# Modo de retrieval LightRAG (paper original):
+#   hybrid — entidades + relaciones + vector chunks (default)
+#   local  — entidades + vector chunks
+#   global — relaciones + vector chunks
+#   naive  — solo vector search, sin KG (= SIMPLE_VECTOR)
+# Todos los modos (excepto naive) presentan secciones separadas al LLM.
 LIGHTRAG_MODE=hybrid
 
 # Profundidad maxima de BFS en graph traversal durante retrieval.
@@ -153,17 +149,6 @@ KG_MAX_HOPS=1
 
 # Max caracteres de documento enviados al LLM para extraccion de tripletas.
 KG_MAX_TEXT_CHARS=3000
-
-# Pesos para fusion de scores vector + graph (deben sumar ~1.0).
-# DTm-62: conditional fusion gate protege contra graph ruidoso.
-# Con overlap bajo, el ranking vectorial se preserva independientemente de estos pesos.
-KG_GRAPH_WEIGHT=0.3
-KG_VECTOR_WEIGHT=0.7
-
-# Metodo de fusion: "rrf" (default, robusto) o "linear" (legacy, candidato a deprecar).
-KG_FUSION_METHOD=rrf
-# Constante k para RRF. Valores mas altos suavizan diferencias de ranking.
-KG_RRF_K=60
 
 # Cap de entidades en el Knowledge Graph. 0 = default (100000).
 # DTm-63: al alcanzar el cap, entidades de baja importancia (1 doc, degree<=1)
@@ -188,10 +173,6 @@ KG_EXTRACTION_MAX_TOKENS=4096
 # tags sin producir JSON. Bajar si hay muchos "Batch parse failed" warnings.
 # Subir (max ~10) solo si el modelo no es thinking-mode o tiene context amplio.
 KG_BATCH_DOCS_PER_CALL=5
-
-# Multiplicador de candidatos en graph traversal. El grafo pide N * top_k
-# candidatos para tener margen tras la fusion con vector.
-KG_GRAPH_OVERFETCH_FACTOR=2
 
 # Directorio para persistir el Knowledge Graph entre runs.
 # Si configurado, el KG se cachea como JSON y se reutiliza si el corpus


### PR DESCRIPTION
## Summary\n\n- Remove stale references to RRF config (`KG_GRAPH_WEIGHT`, `KG_FUSION_METHOD`, `KG_RRF_K`, `KG_GRAPH_OVERFETCH_FACTOR`, `MAX_GRAPH_EXPANSION`, `graph_primary`) from README.md, config.py and env.example\n- Clean dead dependencies from requirements.lock (spacy, networkx, tantivy, rank-bm25) and add correct ones (python-igraph, snowballstemmer)\n\nCherry-picked from `claude/fix-stale-rrf-refs` which had these commits ahead of main.\n\nhttps://claude.ai/code/session_01D8kRWEFrKzV87PwfC4Tjwx