### PR TITLE
docs: contextualize tech debt with admin system integration + experiment 3 hallucination axis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,15 @@ Sistema de evaluacion RAG para benchmarking de pipelines de retrieval y generaci
 
 ## Contexto del producto
 
-Este proyecto es un subsistema de evaluacion RAG, no un producto final. Se integrara dentro de un sistema mas amplio cuya mision es administrar colecciones de datos (corpus documentales) y grafos de conocimiento, orquestando el ciclo de vida de las colecciones, versionado de KGs, consultas multi-tenant y APIs de uso. Los detalles especificos del sistema receptor se definiran mas adelante.
+Este proyecto es un subsistema de evaluacion RAG, no un producto final. Se integrara dentro de un sistema mas amplio cuya mision es administrar colecciones de datos (corpus documentales) y grafos de conocimiento, orquestando el ciclo de vida de las colecciones, versionado de KGs, consultas multi-tenant y APIs de uso.
+
+**Infra compartida con el sistema administrador**: el administrador usa la **misma infraestructura** que este subsistema (MinIO + Parquet como contrato de datos). No hay frontera tecnologica entre ambos: el administrador ingesta PDFs → produce Parquet en MinIO → este subsistema lo consume con el loader actual (`sandbox_mteb/loader.py`). **Este contrato no cambia** con el experimento 3; solo cambia el prefijo MinIO al que apuntamos.
 
 **Implicacion de diseno**: cualquier decision estructural debe favorecer la embedibilidad — configuracion declarativa, interfaces claras entre componentes, ausencia de side-effects globales, capacidad de operar sobre corpus arbitrarios (no solo HotpotQA). El valor de este subsistema no es resolver HotpotQA, es producir metricas fiables sobre cualquier corpus que el sistema administrador le entregue.
 
-**Escenario real de uso esperado**: colecciones pequenas (10-50 PDFs) de dominio especializado, no publico, con idiosincrasia propia (terminologia tecnica, entidades internas, relaciones que no estan en el pre-entrenamiento de los embeddings). En ese regimen se espera que LIGHT_RAG demuestre robustez superior a SIMPLE_VECTOR — hipotesis aun por validar empiricamente (ver "Proximos pasos").
+**Nueva funcionalidad pendiente — export de grafos KG**: cuando LIGHT_RAG se promueva a estrategia de produccion, los KGs construidos por este subsistema deberan **exportarse de vuelta al administrador** (para versionado, reuso entre runs, consultas multi-tenant). Hoy el KG vive solo en memoria (`shared/retrieval/lightrag/knowledge_graph.py`, backend igraph) + ChromaDB para VDBs, y se descarta tras `_cleanup()`. Se necesita un serializador KG → formato persistente (Parquet/JSON con schema compartido con el administrador) y el endpoint/convencion de escritura a MinIO. No implementado.
+
+**Escenario real de uso esperado**: colecciones pequenas (10-50 PDFs) de dominio especializado, no publico, con idiosincrasia propia (terminologia tecnica, entidades internas, relaciones que no estan en el pre-entrenamiento de los embeddings). En ese regimen se espera que LIGHT_RAG demuestre robustez superior a SIMPLE_VECTOR en **dos dimensiones**: (a) precision/recall de retrieval y calidad de respuesta, y (b) resistencia a alucinacion / contexto inventado cuando el embedding no cubre el dominio. Hipotesis aun por validar empiricamente (ver "Proximos pasos").
 
 ## Estructura clave
 
@@ -109,7 +113,7 @@ Diferencias entre esta implementacion y el [LightRAG original (HKUDS/LightRAG, E
 
 | # | Divergencia | Criticidad | Estado |
 |---|---|---|---|
-| 2 | Sin LLM synthesis en fusion final de contexto | **5/10** | Prerequisitos ya resueltos (#4+5, #7): contexto estructurado con secciones separadas y budgets independientes esta implementado. Synthesis es una mejora incremental: reescribir el contexto multi-seccion via LLM en una narrativa coherente antes de pasar al LLM generador. No bloqueante para validacion empirica; evaluar prioridad post re-run F.5. |
+| 2 | Sin LLM synthesis en fusion final de contexto | **7/10** (subida desde 5/10) | Prerequisitos ya resueltos (#4+5, #7): contexto estructurado con secciones separadas y budgets independientes esta implementado. Falta la capa de synthesis: reescribir el contexto multi-seccion (entidades + relaciones + chunks) via LLM en una narrativa coherente antes de pasar al LLM generador. **Por que subio la prioridad**: F.5 post-refactor mostro que presentar secciones separadas + budgets proporcionales no es suficiente sobre HotpotQA, y el experimento 3 evaluara LIGHT_RAG en dominios donde el LLM generador no conoce las entidades del corpus — precisamente el caso donde synthesis aporta: el modelo judge/generador recibe una narrativa que ya conecta entidades, relaciones y evidencia textual, en lugar de tres bloques sueltos que debe recombinar por su cuenta. Esto es tambien linea de defensa contra alucinacion (eje 2 del experimento 3): una narrativa sintetizada del propio corpus reduce el espacio para que el LLM invente conexiones. **Hay que abordarla antes del experimento 3** para que el experimento compare la arquitectura LIGHT_RAG completa, no una version intermedia. Implementacion: paso adicional en `generation_executor.py` que toma el contexto estructurado y llama al LLM para producir una sintesis previa a la generacion final. |
 | 3 | Entity cap 100K | **3/10** | Eviction mejorada con score compuesto. Para HotpotQA (66K docs, ~24K entidades) no se alcanza. |
 
 ### Resueltas (indexacion)
@@ -140,10 +144,10 @@ Runs ejecutadas: SIMPLE_VECTOR y LIGHT_RAG hybrid (125q, 4000 docs, DEV_MODE, se
 | # | Item | Severidad | Ubicacion | Mitigacion temporal |
 |---|---|---|---|---|
 | 1 | ChromaDB: colecciones huerfanas si el proceso se interrumpe | **BAJO** | `evaluator.py:_cleanup()` ahora elimina la coleccion correctamente via `delete_all_documents()` (que llama `delete_collection()` + recrea). Sin embargo, cada run crea `eval_{run_id}` — si el proceso se interrumpe antes de cleanup, la coleccion queda huerfana. Con `PersistentClient`, se acumulan en disco | Aceptable; borrar manualmente `VECTOR_DB_DIR` si se acumulan |
-| 2 | Preflight no valida datos reales | **MEDIO** | `preflight.py` solo verifica bucket MinIO (`head_bucket` + `list_objects MaxKeys=1`). No descarga ni parsea Parquet — dataset corrupto solo falla horas despues. No verifica espacio en disco | `--dry-run` primero y verificar que el dataset carga |
+| 2 | Preflight no valida datos reales | **MEDIO** | `preflight.py` solo verifica bucket MinIO (`head_bucket` + `list_objects MaxKeys=1`). No descarga ni parsea Parquet, no valida schema contra `DATASET_CONFIG`, no verifica espacio en disco. El riesgo principal no es infra (MinIO ya es compartido con el administrador) sino **schema drift del contrato upstream**: cuando el administrador produzca un catalogo nuevo con columnas/tipos/ids diferentes, el fallo ocurre horas despues del start en `_populate_from_dataframes()`, quemando compute | `--dry-run` primero y verificar que el dataset carga |
 | 3 | HNSW no es determinista | **MEDIO** | ChromaDB no expone `hnsw:random_seed` — dos runs con misma config producen rankings con ~2-5% varianza | Ejecutar 2-3 veces y promediar, o aceptar varianza |
-| 4 | LLM Judge puede devolver scores por defecto | **MEDIO-BAJO** | `metrics.py:_extract_score_fallback()` intenta 3 regex patterns (fraccion, decimal, entero con prefijo); si todos fallan retorna 0.5 — sesga metricas silenciosamente. Se logea a WARNING. Deuda a largo plazo: la mitigacion real requiere mas contexto de ventana y/o un modelo judge mas capaz que produzca respuestas estructuradas consistentemente | Post-run, buscar `"Score extraction fallback"` en logs y contar ocurrencias |
-| 5 | Context window fallback silencioso | **BAJO** | `embedding_service.py:resolve_max_context_chars()` — si `GET /v1/models` falla, usa fallback de 4000 chars (~1000 tokens). Puede truncar docs importantes. Se logea WARNING | Configurar `GENERATION_MAX_CONTEXT_CHARS` explicitamente en `.env` |
+| 4 | LLM Judge puede devolver scores por defecto | **MEDIO** (subida desde MEDIO-BAJO) | `metrics.py:_extract_score_fallback()` intenta 3 regex patterns (fraccion, decimal, entero con prefijo); si todos fallan retorna 0.5 — sesga metricas silenciosamente. Se logea a WARNING. **Por que subio la severidad**: el experimento 3 (P0) evalua LIGHT_RAG en dos ejes, y el eje 2 es **resistencia a alucinacion / contexto inventado** — medido principalmente via `faithfulness` (LLM-judge). Si el judge falla a extraer el score y devuelve 0.5 por defecto, esta regresion al centro (a) comprime los deltas entre estrategias, y (b) enmascara la senal mas importante del experimento: LIGHT_RAG deberia *reducir* la alucinacion, no empatar con SIMPLE_VECTOR por artefacto del extractor. Ademas, faithfulness suele ser la metrica donde el judge mas divaga (respuestas largas, mas dificiles de scorear en formato estricto), asi que el fallback se dispara mas aqui que en precision/recall. La mitigacion real requiere constrained decoding / JSON schema y/o un modelo judge mas capaz | Post-run, buscar `"Score extraction fallback"` en logs y contar ocurrencias. **Antes del experimento 3**: (a) instrumentar el judge para fallar el run si la tasa de fallback supera un umbral (p.ej. >2%), (b) reportar tasa de fallback por metrica en el CSV summary |
+| 5 | Context window fallback silencioso | **BAJO** (casi aceptable) | `embedding_service.py:resolve_max_context_chars()` — si `GET /v1/models` falla, usa fallback de 4000 chars (~1000 tokens). **Aclaracion importante**: este valor es el **presupuesto total de contexto** pasado al LLM, que `format_context()`/`format_structured_context()` usan para seleccionar cuantos fragmentos (chunks) caben. No es "el LLM recibe un documento truncado a 4000 chars". Con chunks tipicos de 500-1000 chars, 4000 = ~4-8 chunks relevantes, suficiente para casos tipo HotpotQA (2 docs gold) y para catalogos pequenos de PDFs especializados donde las respuestas suelen estar en 2-5 chunks. Se logea WARNING. El unico riesgo real es dejar senal en la mesa cuando el modelo soporta mucho mas (p.ej. 192K chars): no se "rompe" nada, simplemente no se aprovecha toda la ventana | Configurar `GENERATION_MAX_CONTEXT_CHARS` explicitamente en `.env` si se quiere mayor cobertura |
 | 6 | ~~Suite de tests no portable~~ | ~~CRITICO~~ | **Resuelto.** `conftest.py` ahora mockea `dotenv` (ademas de boto3/langchain/chromadb). `test_knowledge_graph.py` usa `pytest.importorskip("igraph")` para skip limpio sin igraph. Con `python-igraph` + `snowballstemmer` instalados: 409 pasan, 6 skipped. Sin igraph: 344 pasan, 65 skipped |
 | 7 | ~~Validacion empirica pendiente post-refactor~~ | **RESUELTO** | F.5 re-ejecutado post-refactor (abril 2026) con las tres divergencias corregidas. Resultado: delta LIGHT_RAG vs SIMPLE_VECTOR se mantuvo en +1.19pp (vs +1.13pp pre-fix) — dentro del ruido del LLM judge. Los fixes estan bien implementados pero HotpotQA no los discrimina por ser home turf del embedding + DEV_MODE saturado + ventana de contexto amplia. Ver "Proximos pasos" para la siguiente direccion (experimento 3, dataset especializado). | N/A — la siguiente validacion requiere cambiar de dataset, no mas fixes |
 | 8 | Infraestructura pesada para el scope | **BAJO** | Para 1 dataset y 2 estrategias, la infraestructura (checkpoint, preflight, JSONL, export dual, subset selection, DEV_MODE) es considerable. Sin embargo, el run F.5 demostro que esta infraestructura funciona y es util en practica | Aceptado — la infraestructura se justifica con uso real |
@@ -205,10 +209,10 @@ Delta pre-refactor era +0.0113. Delta post-refactor es +0.0119. **Los tres fixes
 La hipotesis del proyecto, alineada con su escenario real de uso (ver "Contexto del producto"), es que **LIGHT_RAG mantiene su rendimiento cuando el embedding se degrada por domain shift**, mientras que SIMPLE_VECTOR colapsa. HotpotQA no puede validar esto. El dataset especializado no sera un MTEB/BeIR publico — sera un **catalogo de PDFs de dominio especializado** gestionado por el futuro sistema administrador.
 
 **Separacion de responsabilidades**:
-- **Sistema administrador (futuro)**: ingesta de PDFs, chunking, extraccion de queries y qrels, almacenamiento en MinIO como Parquet. Define el catalogo.
+- **Sistema administrador**: ingesta de PDFs, chunking, extraccion de queries y qrels, almacenamiento en MinIO como Parquet. Define el catalogo. **La generacion del catalogo y su storage NO dependen de este subsistema** — son upstream.
 - **Este subsistema (repo actual)**: consume el catalogo desde MinIO con el loader actual (`sandbox_mteb/loader.py`), ejecuta SIMPLE_VECTOR y LIGHT_RAG, produce metricas comparativas.
 
-La interfaz entre ambos es el formato Parquet de queries/corpus/qrels que ya consume el loader para HotpotQA. **No hace falta cambiar la forma de consumir datos** — solo apuntar a un prefijo MinIO distinto con el nuevo catalogo.
+La interfaz entre ambos es el formato Parquet de queries/corpus/qrels que ya consume el loader para HotpotQA. **No hace falta cambiar la forma de consumir datos** — solo apuntar a un prefijo MinIO distinto con el nuevo catalogo. El riesgo tecnico aqui es **schema drift del contrato upstream**, no disponibilidad del dato.
 
 **Trabajo tecnico necesario** (cuando el administrador este listo):
 1. Confirmar que el administrador produce Parquet con el mismo schema que HotpotQA (columnas, tipos, ids). Si diverge, adaptar `_populate_from_dataframes()` en `loader.py` o pedir que el administrador se alinee con el schema existente.
@@ -216,21 +220,44 @@ La interfaz entre ambos es el formato Parquet de queries/corpus/qrels que ya con
 3. Parametrizar `S3_DATASETS_PREFIX` en `.env` para apuntar al catalogo nuevo.
 4. Ejecutar F.6 comparativo (SIMPLE_VECTOR vs LIGHT_RAG hybrid) con metodologia estandar: seed fijo, subset reproducible, DEV_MODE para iteracion rapida + run completo para validacion final.
 
-**Hipotesis a validar**: sobre un catalogo de 10-50 PDFs especializados (no publicos, terminologia propia, entidades internas), el delta LIGHT_RAG > SIMPLE_VECTOR crece significativamente (>3-5pp en gen score, >5-10pp en Recall@K) porque el embedding no tiene el dominio aprendido mientras que el KG se construye a partir del corpus mismo. Si se valida, este subsistema queda justificado como pieza del producto final y LIGHT_RAG pasa a ser estrategia default. Si no se valida, hay que reconsiderar el rol de LIGHT_RAG en el producto.
+**Hipotesis a validar — dos dimensiones**:
+
+El experimento 3 evalua LIGHT_RAG vs SIMPLE_VECTOR en **dos ejes complementarios**, no solo uno:
+
+*Eje 1 — Precision/calidad de respuesta*: sobre un catalogo de 10-50 PDFs especializados (no publicos, terminologia propia, entidades internas), se espera que el delta LIGHT_RAG > SIMPLE_VECTOR crezca significativamente (>3-5pp en gen score, >5-10pp en Recall@K) porque el embedding no tiene el dominio aprendido mientras que el KG se construye a partir del corpus mismo.
+
+*Eje 2 — Resistencia a alucinacion / contexto inventado*: cuando el retrieval del embedding falla o devuelve chunks poco relevantes por domain shift, el LLM tiende a rellenar con contenido plausible pero no respaldado por el corpus. El KG, al operar sobre entidades y relaciones extraidas explicitamente del propio corpus, deberia (a) aportar grounding adicional que reduzca la tasa de alucinacion, y (b) evitar que el LLM fabrique entidades o relaciones inexistentes. Metricamente esto se evalua con `faithfulness` (LLM-judge en `shared/metrics.py`) como senal principal, complementada con analisis de respuestas donde LIGHT_RAG acierta y SIMPLE_VECTOR inventa (y viceversa).
+
+Este segundo eje es **especialmente relevante** porque el escenario real de uso (corpus especializado, no publico) es exactamente donde el LLM tiene mayor incentivo a alucinar: las entidades del corpus no estan en su pre-entrenamiento, asi que al no encontrarlas en el contexto recuperado, puede fabricarlas con confianza.
+
+**Criterio de decision**: si se valida cualquiera de los dos ejes (idealmente ambos), este subsistema queda justificado como pieza del producto final y LIGHT_RAG pasa a ser estrategia default. Si no se valida ninguno, hay que reconsiderar el rol de LIGHT_RAG en el producto.
+
+**Prerequisito metodologico**: la fiabilidad del eje 2 depende de la calidad del LLM-judge de faithfulness. Ver deuda tecnica #4 — el fallback silencioso del score extractor puede sesgar precisamente la metrica que mide alucinacion.
 
 **Bloqueado por**: disponibilidad del catalogo en el administrador. Mientras tanto, el experimento 1 (P1) puede dar senal intermedia sobre robustez del KG en condiciones de retrieval dificil, sobre el mismo dataset HotpotQA.
+
+### P0.5 — Prerequisitos arquitectonicos del experimento 3
+
+Antes de ejecutar el experimento 3, hay trabajo de arquitectura que debe completarse para que la comparacion evalue la arquitectura LIGHT_RAG **completa**, no una version intermedia:
+
+1. **Divergencia LightRAG #2 (LLM synthesis en fusion final)** — ver "Divergencias con el paper original". La indexacion y la presentacion estructurada ya estan; falta la capa de synthesis que convierta entidades + relaciones + chunks en narrativa coherente antes de la generacion. Es especialmente relevante para el eje 2 del experimento 3 (resistencia a alucinacion).
+2. **Deuda #4 (LLM judge fallback)** — instrumentar tasa de fallback y fallar el run si supera umbral; sin esto, el eje 2 (faithfulness) puede reportar deltas artefacto.
+3. **Deuda #2 (preflight real)** — validar schema del Parquet contra `DATASET_CONFIG` para detectar schema drift del contrato upstream en segundos, no en horas.
+
+Los tres son baratos individualmente y evitan que el experimento 3 produzca senal no interpretable.
 
 ### P1 — Experimento 1 (control intermedio, no bloqueante)
 
 Control experimental gratis antes de invertir en adaptacion de dataset nuevo: desactivar DEV_MODE sobre HotpotQA y usar corpus completo (66K docs). No reemplaza el experimento 3, pero da senal rapida sobre si el KG aporta valor cuando el retrieval se vuelve dificil (sin gold docs garantizados en el corpus). Coste: 0 codigo, ~2-3h de infraestructura.
 
-### P2 — Embedibilidad del subsistema (preparacion para integracion)
+### P2 — Embedibilidad del subsistema + export de KG (preparacion para integracion)
 
 Auditar interfaces pensando en el sistema administrador que integrara este subsistema:
 - Configuracion via diccionario inyectado, no solo via `.env` global
 - Operacion sobre corpus pasados en memoria (no solo MinIO/Parquet)
 - Sin asunciones sobre el sistema de ficheros excepto `EVALUATION_RESULTS_DIR` explicito
 - Separacion limpia entre "cargar/indexar" y "evaluar" para permitir reuso de indices entre runs
+- **Export de KG a MinIO/Parquet**: cuando LIGHT_RAG sea estrategia de produccion, el administrador necesitara persistir los KGs construidos (para versionado, reuso multi-run y consultas multi-tenant). Implementar serializador `KnowledgeGraph` → Parquet (nodos + aristas + pesos + metadatos de co-ocurrencia) + VDBs de entidades/relaciones. Schema a acordar con el administrador; se recomienda espejar la estructura que el administrador usa para consumir KGs. Hoy el KG vive solo en memoria (igraph) + ChromaDB efimeros y se descarta en `_cleanup()`.
 
 No bloqueante para el experimento 3, pero necesario antes de la integracion real.
 


### PR DESCRIPTION
## Summary

Actualizacion de `CLAUDE.md` para reflejar con mayor precision el contexto de integracion con el sistema administrador y reordenar la deuda tecnica en funcion del experimento 3.

### Cambios

- **Contexto del producto**: se documenta que admin + subsistema comparten infra (MinIO/Parquet) y se introduce el requisito pendiente de **export de grafos KG** cuando LIGHT_RAG sea estrategia de produccion.
- **Experimento 3 (P0)**: la hipotesis se reformula en **dos ejes**: (1) precision/recall y calidad de respuesta, (2) resistencia a alucinacion / contexto inventado (via `faithfulness`). Aclarada tambien la separacion de responsabilidades: la generacion del catalogo es upstream.
- **Deuda #2 (preflight)**: re-framing como defensa contra schema drift del contrato upstream, no riesgo de infra.
- **Deuda #4 (LLM judge fallback)**: subida MEDIO-BAJO → MEDIO. El fallback silencioso a 0.5 sesga precisamente la metrica (`faithfulness`) que mide el eje 2 del experimento 3.
- **Deuda #5 (context window fallback)**: correccion factual — 4000 chars es el presupuesto *total* de contexto (varios chunks), no una truncacion por documento. Severidad ajustada a BAJO / casi aceptable.
- **Divergencia LightRAG #2 (synthesis)**: subida 5/10 → 7/10. Se anade como prerequisito arquitectonico del experimento 3.
- **Nueva seccion P0.5**: prerequisitos arquitectonicos antes del experimento 3 (synthesis + instrumentacion del judge + preflight real).
- **P2**: ampliado con el requisito de export de KG a MinIO/Parquet.

## Test plan

- [x] Solo cambios de documentacion en `CLAUDE.md` — sin impacto en codigo, tests o runtime
- [x] `git diff --stat`: 1 file changed, +37 / -10
- [x] Working tree limpio tras commit

https://claude.ai/code/session_017DswjS7P5HFg3WiEum7Epv