### PR TITLE
feat: judge fallback instrumentation + KG context synthesis + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,29 +91,29 @@ Inspirada en [LightRAG (EMNLP 2025)](https://arxiv.org/abs/2410.05779).
 
 **Modos** (`LIGHTRAG_MODE`): `naive` (solo chunks), `local` (entidades + chunks), `global` (relaciones + chunks), `hybrid` (default, entidades + relaciones + chunks). Todos los modos (excepto naive) presentan secciones separadas al LLM.
 
-**Fallback**: sin igraph o sin LLM → degrada a SimpleVectorRetriever puro.
+**Synthesis del contexto (divergencia #2, resuelta)**: para queries con datos KG, `GenerationExecutor._synthesize_kg_context_async()` llama al LLM con `KG_SYNTHESIS_SYSTEM_PROMPT` (query-aware, anti-fabricacion) para reescribir las 3 secciones como narrativa coherente *antes* de pasarla al LLM generador. Faithfulness se sigue evaluando contra el contexto estructurado original (no contra la narrativa) para penalizar cualquier alucinacion introducida por la propia synthesis. Stats por evento (invocations / successes / errors / empty / truncations / timeouts / fallback_rate) en `config_snapshot._runtime.kg_synthesis_stats`. Toggle `KG_SYNTHESIS_ENABLED` (default `true` para LIGHT_RAG) permite A/B sin synthesis.
 
-**Alineacion con original (DAM-1 a DAM-8)**: Entity VDB, Relationship VDB, edge weights (log1p), gleaning, BFS 1-hop weighted, co-occurrence bridging, LLM description synthesis — todo implementado.
+**Fallback**: sin igraph o sin LLM → degrada a SimpleVectorRetriever puro. Fallos en la capa de synthesis → degrada al contexto estructurado (run nunca se rompe).
 
-**Divergencia arquitectonica critica**: pese a lo anterior, el pipeline de retrieval+generacion **no replica la arquitectura del paper**. La indexacion es fiel, pero la forma en que se consumen los resultados del KG difiere fundamentalmente (ver seccion siguiente).
+**Alineacion con original (DAM-1 a DAM-8 + divergencias #4+5/#6/#7/#2)**: Entity VDB, Relationship VDB, edge weights (log1p), gleaning, BFS 1-hop weighted, co-occurrence bridging, LLM description synthesis, secciones separadas al LLM con budgets proporcionales, reranker off para LIGHT_RAG, synthesis final del contexto — todo implementado. Pendiente: ejecutar runs comparativos post-synthesis.
 
 ## Divergencias con el paper original — evaluacion de criticidad
 
-Diferencias entre esta implementacion y el [LightRAG original (HKUDS/LightRAG, EMNLP 2025)](https://arxiv.org/abs/2410.05779). Validadas empiricamente en F.5 (125q, 4000 docs, seed=42): LIGHT_RAG produjo metricas de retrieval **identicas** a SIMPLE_VECTOR, confirmando que las divergencias arquitectonicas anulan la contribucion del KG.
+Diferencias entre esta implementacion y el [LightRAG original (HKUDS/LightRAG, EMNLP 2025)](https://arxiv.org/abs/2410.05779). Validadas empiricamente en F.5 (125q, 4000 docs, seed=42). Todas las divergencias arquitectonicas (4+5, 6, 7, 2) estan resueltas. Pendiente ejecutar runs comparativos post-synthesis sobre ambas estrategias para validar el delta acumulado.
 
 ### Divergencias arquitectonicas (descubiertas en F.5)
 
 | # | Divergencia | Criticidad | Detalle |
 |---|---|---|---|
-| 4+5 | ~~**Pipeline de consumo diverge del paper**~~ | ~~9/10~~ | **Resuelto.** RRF eliminado (`reciprocal_rank_fusion()`, `_full_fusion()`, `_vector_first_fusion()`, `_fuse_with_graph()` eliminados). `_enrich_with_graph()` recopila entidades y relaciones relevantes a la query via VDB y las propaga en `retrieval_metadata` como `kg_entities`/`kg_relations`. `generation_executor.py:89-103` invoca `format_structured_context()` que presenta secciones separadas al LLM. `graph_primary` (DAM-3) eliminado. |
+| 4+5 | ~~**Pipeline de consumo diverge del paper**~~ | ~~9/10~~ | **Resuelto.** RRF eliminado (`reciprocal_rank_fusion()`, `_full_fusion()`, `_vector_first_fusion()`, `_fuse_with_graph()` eliminados). `_enrich_with_graph()` recopila entidades y relaciones relevantes a la query via VDB y las propaga en `retrieval_metadata` como `kg_entities`/`kg_relations`. `generation_executor.py` invoca `format_structured_context()` que presenta secciones separadas al LLM. `graph_primary` (DAM-3) eliminado. |
 | 6 | ~~**Reranker post-fusion anula senal del grafo**~~ | ~~8/10~~ | **Resuelto.** El `CrossEncoderReranker` ahora se desactiva automaticamente cuando `strategy=LIGHT_RAG` (`retrieval_executor.py:100-105`). Se mantiene activo para `SIMPLE_VECTOR`. |
-| 7 | ~~**Sin token budgets separados por tipo**~~ | ~~5/10~~ | **Resuelto.** `format_structured_context()` en `retrieval_executor.py` ahora divide `max_context_chars` en presupuestos proporcionales segun el modo LightRAG: `hybrid` (20%/20%/60%), `local` (30%/0%/70%), `global` (0%/30%/70%). Budget no usado por KG se redistribuye a chunks, evitando que ninguna seccion aplaste a las otras. `generation_executor.py:89-107` propaga `lightrag_mode` desde `retrieval_metadata`. **Pendiente validacion empirica** (ver deuda tecnica #7). |
+| 7 | ~~**Sin token budgets separados por tipo**~~ | ~~5/10~~ | **Resuelto.** `format_structured_context()` en `retrieval_executor.py` ahora divide `max_context_chars` en presupuestos proporcionales segun el modo LightRAG: `hybrid` (20%/20%/60%), `local` (30%/0%/70%), `global` (0%/30%/70%). Budget no usado por KG se redistribuye a chunks, evitando que ninguna seccion aplaste a las otras. `generation_executor.py` propaga `lightrag_mode` desde `retrieval_metadata`. |
+| 2 | ~~**Sin LLM synthesis en fusion final**~~ | ~~7/10~~ | **Resuelto.** `GenerationExecutor._synthesize_kg_context_async()` reescribe el contexto multi-seccion (entidades + relaciones + chunks) como narrativa coherente via LLM antes de la generacion final. Prompt query-aware en `sandbox_mteb/config.py:KG_SYNTHESIS_SYSTEM_PROMPT` con reglas anti-fabricacion y citas `[ref:N]` inline. Se activa automaticamente para LIGHT_RAG (`KG_SYNTHESIS_ENABLED=true` default). **Faithfulness se evalua contra el contexto estructurado original**, no contra la narrativa, para penalizar cualquier alucinacion introducida por la propia capa de synthesis. Degradacion graceful: error LLM / vacio / timeout → fallback al contexto estructurado; stats por evento en `config_snapshot._runtime.kg_synthesis_stats`. |
 
 ### Divergencias menores (preexistentes)
 
 | # | Divergencia | Criticidad | Estado |
 |---|---|---|---|
-| 2 | Sin LLM synthesis en fusion final de contexto | **7/10** (subida desde 5/10) | Prerequisitos ya resueltos (#4+5, #7): contexto estructurado con secciones separadas y budgets independientes esta implementado. Falta la capa de synthesis: reescribir el contexto multi-seccion (entidades + relaciones + chunks) via LLM en una narrativa coherente antes de pasar al LLM generador. **Por que subio la prioridad**: F.5 post-refactor mostro que presentar secciones separadas + budgets proporcionales no es suficiente sobre HotpotQA, y el experimento 3 evaluara LIGHT_RAG en dominios donde el LLM generador no conoce las entidades del corpus — precisamente el caso donde synthesis aporta: el modelo judge/generador recibe una narrativa que ya conecta entidades, relaciones y evidencia textual, en lugar de tres bloques sueltos que debe recombinar por su cuenta. Esto es tambien linea de defensa contra alucinacion (eje 2 del experimento 3): una narrativa sintetizada del propio corpus reduce el espacio para que el LLM invente conexiones. **Hay que abordarla antes del experimento 3** para que el experimento compare la arquitectura LIGHT_RAG completa, no una version intermedia. Implementacion: paso adicional en `generation_executor.py` que toma el contexto estructurado y llama al LLM para producir una sintesis previa a la generacion final. |
 | 3 | Entity cap 100K | **3/10** | Eviction mejorada con score compuesto. Para HotpotQA (66K docs, ~24K entidades) no se alcanza. |
 
 ### Resueltas (indexacion)
@@ -146,14 +146,32 @@ Runs ejecutadas: SIMPLE_VECTOR y LIGHT_RAG hybrid (125q, 4000 docs, DEV_MODE, se
 | 1 | ChromaDB: colecciones huerfanas si el proceso se interrumpe | **BAJO** | `evaluator.py:_cleanup()` ahora elimina la coleccion correctamente via `delete_all_documents()` (que llama `delete_collection()` + recrea). Sin embargo, cada run crea `eval_{run_id}` — si el proceso se interrumpe antes de cleanup, la coleccion queda huerfana. Con `PersistentClient`, se acumulan en disco | Aceptable; borrar manualmente `VECTOR_DB_DIR` si se acumulan |
 | 2 | Preflight no valida datos reales | **MEDIO** | `preflight.py` solo verifica bucket MinIO (`head_bucket` + `list_objects MaxKeys=1`). No descarga ni parsea Parquet, no valida schema contra `DATASET_CONFIG`, no verifica espacio en disco. El riesgo principal no es infra (MinIO ya es compartido con el administrador) sino **schema drift del contrato upstream**: cuando el administrador produzca un catalogo nuevo con columnas/tipos/ids diferentes, el fallo ocurre horas despues del start en `_populate_from_dataframes()`, quemando compute | `--dry-run` primero y verificar que el dataset carga |
 | 3 | HNSW no es determinista | **MEDIO** | ChromaDB no expone `hnsw:random_seed` — dos runs con misma config producen rankings con ~2-5% varianza | Ejecutar 2-3 veces y promediar, o aceptar varianza |
-| 4 | LLM Judge puede devolver scores por defecto | **MEDIO** (subida desde MEDIO-BAJO) | `metrics.py:_extract_score_fallback()` intenta 3 regex patterns (fraccion, decimal, entero con prefijo); si todos fallan retorna 0.5 — sesga metricas silenciosamente. Se logea a WARNING. **Por que subio la severidad**: el experimento 3 (P0) evalua LIGHT_RAG en dos ejes, y el eje 2 es **resistencia a alucinacion / contexto inventado** — medido principalmente via `faithfulness` (LLM-judge). Si el judge falla a extraer el score y devuelve 0.5 por defecto, esta regresion al centro (a) comprime los deltas entre estrategias, y (b) enmascara la senal mas importante del experimento: LIGHT_RAG deberia *reducir* la alucinacion, no empatar con SIMPLE_VECTOR por artefacto del extractor. Ademas, faithfulness suele ser la metrica donde el judge mas divaga (respuestas largas, mas dificiles de scorear en formato estricto), asi que el fallback se dispara mas aqui que en precision/recall. La mitigacion real requiere constrained decoding / JSON schema y/o un modelo judge mas capaz | Post-run, buscar `"Score extraction fallback"` en logs y contar ocurrencias. **Antes del experimento 3**: (a) instrumentar el judge para fallar el run si la tasa de fallback supera un umbral (p.ej. >2%), (b) reportar tasa de fallback por metrica en el CSV summary |
+| 4 | ~~LLM Judge puede devolver scores por defecto~~ | **RESUELTO** (instrumentacion) | `shared/metrics.py` implementa `_JudgeFallbackTracker` thread-safe con contadores por `MetricType`: `invocations`, `parse_failures` (JSON no parseable), `default_returns` (regex fallo → 0.5). APIs publicas: `get_judge_fallback_stats()`, `reset_judge_fallback_stats()`, `max_judge_default_return_rate()`. `_extract_score_fallback` refactorizado a variante con status `(score, was_default)` preservando la API publica existente. `_parse_judge_result` loguea WARNING con raw response (trunc 200) cuando se devuelve el default. El evaluator resetea stats al inicio del run, las propaga a `config_snapshot._runtime.judge_fallback_stats`, y aplica threshold check post-run via `JUDGE_FALLBACK_THRESHOLD` (default `0.02`): si alguna metrica supera el umbral, el run lanza `RuntimeError` y emite evento estructurado `run_judge_threshold_exceeded`. El sesgo silencioso de las metricas del judge (especialmente faithfulness para el eje 2 del experimento 3) queda protegido. La mitigacion de la causa raiz (constrained decoding / JSON schema / judge mas capaz) sigue pendiente pero ya no silenciosa | N/A — la instrumentacion expone el problema. Ver `config_snapshot._runtime.judge_fallback_stats` en output JSON |
 | 5 | Context window fallback silencioso | **BAJO** (casi aceptable) | `embedding_service.py:resolve_max_context_chars()` — si `GET /v1/models` falla, usa fallback de 4000 chars (~1000 tokens). **Aclaracion importante**: este valor es el **presupuesto total de contexto** pasado al LLM, que `format_context()`/`format_structured_context()` usan para seleccionar cuantos fragmentos (chunks) caben. No es "el LLM recibe un documento truncado a 4000 chars". Con chunks tipicos de 500-1000 chars, 4000 = ~4-8 chunks relevantes, suficiente para casos tipo HotpotQA (2 docs gold) y para catalogos pequenos de PDFs especializados donde las respuestas suelen estar en 2-5 chunks. Se logea WARNING. El unico riesgo real es dejar senal en la mesa cuando el modelo soporta mucho mas (p.ej. 192K chars): no se "rompe" nada, simplemente no se aprovecha toda la ventana | Configurar `GENERATION_MAX_CONTEXT_CHARS` explicitamente en `.env` si se quiere mayor cobertura |
 | 6 | ~~Suite de tests no portable~~ | ~~CRITICO~~ | **Resuelto.** `conftest.py` ahora mockea `dotenv` (ademas de boto3/langchain/chromadb). `test_knowledge_graph.py` usa `pytest.importorskip("igraph")` para skip limpio sin igraph. Con `python-igraph` + `snowballstemmer` instalados: 409 pasan, 6 skipped. Sin igraph: 344 pasan, 65 skipped |
 | 7 | ~~Validacion empirica pendiente post-refactor~~ | **RESUELTO** | F.5 re-ejecutado post-refactor (abril 2026) con las tres divergencias corregidas. Resultado: delta LIGHT_RAG vs SIMPLE_VECTOR se mantuvo en +1.19pp (vs +1.13pp pre-fix) — dentro del ruido del LLM judge. Los fixes estan bien implementados pero HotpotQA no los discrimina por ser home turf del embedding + DEV_MODE saturado + ventana de contexto amplia. Ver "Proximos pasos" para la siguiente direccion (experimento 3, dataset especializado). | N/A — la siguiente validacion requiere cambiar de dataset, no mas fixes |
 | 8 | Infraestructura pesada para el scope | **BAJO** | Para 1 dataset y 2 estrategias, la infraestructura (checkpoint, preflight, JSONL, export dual, subset selection, DEV_MODE) es considerable. Sin embargo, el run F.5 demostro que esta infraestructura funciona y es util en practica | Aceptado — la infraestructura se justifica con uso real |
 | 9 | Lock-in a NVIDIA NIM | **MEDIO** | Embeddings, LLM y reranker estan acoplados a NIM sin abstraccion de provider. Para un sistema de evaluacion, esto limita la reproducibilidad — nadie sin acceso a NIM puede ejecutar ni validar resultados | Abstraer detras de interfaces (ya existen Protocols en types.py pero no se usan para desacoplar el provider) |
 
-Las divergencias arquitectonicas #4/#5/#6 son la causa raiz de que LIGHT_RAG no aporte valor. Ver seccion "Divergencias con el paper original".
+Las divergencias arquitectonicas #4/#5/#6/#7/#2 estan todas resueltas (ver seccion "Divergencias con el paper original"). La proxima validacion empirica requiere runs comparativos SIMPLE_VECTOR vs LIGHT_RAG con synthesis activo/inactivo.
+
+## Observabilidad de runs
+
+Los `EvaluationRun` exportados a JSON incluyen en `config_snapshot._runtime` dos bloques de stats para auditoria post-run:
+
+**`judge_fallback_stats`** (deuda #4): por cada `MetricType` del judge (`faithfulness`, `answer_relevance`) reporta `invocations`, `parse_failures` (JSON no parseable), `default_returns` (0.5 por defecto), `parse_failure_rate`, `default_return_rate`. Si `default_return_rate > JUDGE_FALLBACK_THRESHOLD` (default 2%) en cualquier metrica, el run falla con `RuntimeError`.
+
+```bash
+jq '.config_snapshot._runtime.judge_fallback_stats' data/results/<run_id>.json
+```
+
+**`kg_synthesis_stats`** (divergencia LightRAG #2): cuando `KG_SYNTHESIS_ENABLED=true` y la estrategia es `LIGHT_RAG`, reporta `invocations`, `successes`, `errors`, `empty_returns`, `truncations`, `timeouts`, `fallback_rate`. `fallback_rate > 10%` indica degradacion frecuente — el run no refleja la arquitectura completa.
+
+```bash
+jq '.config_snapshot._runtime.kg_synthesis_stats' data/results/<run_id>.json
+```
+
+Ambos tambien se emiten en el evento estructurado `run_complete` del JSONL y en logs INFO al final de cada run.
 
 ## Bare excepts aceptados (no criticos)
 
@@ -163,14 +181,15 @@ Estos `except Exception as e:` logean el error pero no lo re-lanzan. Aceptable p
 |---|---|
 | `reranker.py:147` | Reranking error — retorna fallback sin rerank |
 | `vector_store.py:126, 142, 179, 232, 247` | Operaciones ChromaDB — retorna fallback (lista vacia, dict vacio, o continua cleanup) |
+| `generation_executor.py` (`_synthesize_kg_context_async`) | `asyncio.TimeoutError` + `Exception` genericos durante synthesis KG — fallback al contexto estructurado. Todos los eventos contabilizados en `kg_synthesis_stats` (errors/timeouts) |
 
 ## Test coverage
 
 | Metrica | Valor (abril 2026) |
 |---|---|
-| Tests unitarios | **409 pasan**, 6 skipped (integracion marker) en entorno con igraph+snowballstemmer. Sin igraph: 344 pasan, 65 skipped |
+| Tests unitarios | **~441 pasan**, 6 skipped en entorno con igraph+snowballstemmer. Sin igraph: **382 pasan**, 7 skipped (verificado). Ultimas adiciones: +19 `test_judge_fallback_tracker.py` (deuda #4) +13 `test_kg_synthesis.py` (divergencia #2) |
 | Tests integracion | 19 en 3 archivos, requieren NIM + MinIO reales |
-| mypy | 0 errores (27 source files) — no verificado en entorno limpio |
+| mypy | 0 errores nuevos en ficheros modificados; 3 errores preexistentes no relacionados (dotenv/numpy sin stubs, `retrieval_executor.py:124` union-attr) |
 
 ### Portabilidad de tests
 
@@ -240,11 +259,11 @@ Este segundo eje es **especialmente relevante** porque el escenario real de uso 
 
 Antes de ejecutar el experimento 3, hay trabajo de arquitectura que debe completarse para que la comparacion evalue la arquitectura LIGHT_RAG **completa**, no una version intermedia:
 
-1. **Divergencia LightRAG #2 (LLM synthesis en fusion final)** — ver "Divergencias con el paper original". La indexacion y la presentacion estructurada ya estan; falta la capa de synthesis que convierta entidades + relaciones + chunks en narrativa coherente antes de la generacion. Es especialmente relevante para el eje 2 del experimento 3 (resistencia a alucinacion).
-2. **Deuda #4 (LLM judge fallback)** — instrumentar tasa de fallback y fallar el run si supera umbral; sin esto, el eje 2 (faithfulness) puede reportar deltas artefacto.
-3. **Deuda #2 (preflight real)** — validar schema del Parquet contra `DATASET_CONFIG` para detectar schema drift del contrato upstream en segundos, no en horas.
+1. ~~**Divergencia LightRAG #2 (LLM synthesis en fusion final)**~~ — **Resuelto.** `GenerationExecutor._synthesize_kg_context_async()` reescribe el contexto multi-seccion como narrativa coherente via LLM query-aware. Activado por defecto para LIGHT_RAG via `KG_SYNTHESIS_ENABLED=true`. Ver "Divergencias con el paper original".
+2. ~~**Deuda #4 (LLM judge fallback)**~~ — **Resuelto.** Tracker instrumentado + threshold check via `JUDGE_FALLBACK_THRESHOLD` (default 2%). Tasas por metrica en `config_snapshot._runtime.judge_fallback_stats`. Ver deuda tecnica #4.
+3. **Deuda #2 (preflight real)** — **Pendiente.** Validar schema del Parquet contra `DATASET_CONFIG` para detectar schema drift del contrato upstream en segundos, no en horas. Es el unico prerequisito P0.5 vivo.
 
-Los tres son baratos individualmente y evitan que el experimento 3 produzca senal no interpretable.
+Post-synthesis conviene ejecutar runs comparativos en HotpotQA (SIMPLE_VECTOR vs LIGHT_RAG con synthesis on/off) para (a) validar que la implementacion no introduce regresion y (b) medir el delta aislado que aporta la capa de synthesis. Si `kg_synthesis_stats.fallback_rate > 10%`, la synthesis esta degradando frecuentemente y los resultados no reflejan la arquitectura completa.
 
 ### P1 — Experimento 1 (control intermedio, no bloqueante)
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Sistema de evaluacion RAG (Retrieval-Augmented Generation) para benchmarking de 
 | Estrategia | Indexacion | Busqueda | Reranker |
 |---|---|---|---|
 | `SIMPLE_VECTOR` | Embedding directo (NIM) | Cosine similarity (ChromaDB) | Opcional |
-| `LIGHT_RAG` | LLM triplet extraction + KG + Embedding | Vector + KG enrichment (secciones separadas) | Opcional |
+| `LIGHT_RAG` | LLM triplet extraction + KG + Embedding | Vector + KG enrichment + LLM synthesis del contexto | Off (auto-desactivado) |
 
-**LIGHT_RAG** es una implementacion inspirada en [LightRAG (EMNLP 2025)](https://arxiv.org/abs/2410.05779). Combina busqueda vectorial con un knowledge graph construido via LLM. Entity VDB + Relationship VDB para resolucion semantica. 4 modos configurables via `LIGHTRAG_MODE`: `hybrid` (default), `local`, `global`, `naive`. Sin `igraph` o sin LLM → degrada a vector search puro.
+**LIGHT_RAG** es una implementacion inspirada en [LightRAG (EMNLP 2025)](https://arxiv.org/abs/2410.05779). Combina busqueda vectorial con un knowledge graph construido via LLM. Entity VDB + Relationship VDB para resolucion semantica. 4 modos configurables via `LIGHTRAG_MODE`: `hybrid` (default), `local`, `global`, `naive`. Tras el retrieval, una capa de synthesis LLM (query-aware, `KG_SYNTHESIS_ENABLED`) reescribe el contexto multi-seccion (entidades + relaciones + chunks) como narrativa coherente antes de la generacion final. Sin `igraph` o sin LLM → degrada a vector search puro; fallos de synthesis → degrada al contexto estructurado.
 
 ## Arquitectura
 
@@ -44,7 +44,7 @@ sandbox_mteb/                    # Pipeline de evaluacion MTEB/BeIR
   preflight.py                   # Validacion pre-run (deps, NIM, MinIO)
   env.example                    # Plantilla .env
 
-tests/                           # pytest (447 unit + 19 integration tests, 38 archivos)
+tests/                           # pytest (~441 unit + 19 integration tests, 40 archivos)
 ```
 
 ## Pipeline
@@ -56,7 +56,9 @@ tests/                           # pytest (447 unit + 19 integration tests, 38 a
      -> index(ChromaDB)
      -> pre-embed queries (batch REST NIM)
      -> [pre-extract query keywords (batch LLM) si LIGHT_RAG]
-     -> retrieve (sync) -> [rerank si habilitado] -> generate + metrics (async)
+     -> retrieve (sync) -> [rerank si SIMPLE_VECTOR]
+     -> [LLM synthesis del contexto KG si LIGHT_RAG + kg_synthesis_enabled]
+     -> generate + metrics (async)
      -> EvaluationRun -> JSON + CSV
 ```
 
@@ -115,9 +117,14 @@ KG_BATCH_DOCS_PER_CALL=5             # Docs por LLM call en batch
 KG_MAX_ENTITIES=0                     # Cap entidades (0 = default interno 100K)
 KG_CACHE_DIR=                         # Directorio para persistir KG (vacio = sin cache)
 KG_DESCRIPTION_SYNTHESIS=false        # LLM synthesis para descripciones multi-doc (DAM-4)
-KG_SYNTHESIS_CHAR_THRESHOLD=200       # Chars minimos para trigger LLM synthesis
+KG_SYNTHESIS_CHAR_THRESHOLD=200       # Chars minimos para trigger LLM synthesis (DAM-4)
 
-# Reranker (opcional)
+# KG context synthesis en generacion (divergencia LightRAG #2)
+KG_SYNTHESIS_ENABLED=true             # LLM reescribe contexto multi-seccion como narrativa
+KG_SYNTHESIS_MAX_CHARS=0              # 0 = usar max_context_chars del run
+KG_SYNTHESIS_TIMEOUT_S=30.0
+
+# Reranker (opcional, desactivado automaticamente para LIGHT_RAG)
 RERANKER_ENABLED=false
 RERANKER_TOP_N=5
 
@@ -126,6 +133,9 @@ MTEB_DATASET_NAME=hotpotqa
 EVAL_MAX_QUERIES=50
 EVAL_MAX_CORPUS=1000
 GENERATION_ENABLED=true
+
+# LLM judge instrumentation (deuda tecnica #4)
+JUDGE_FALLBACK_THRESHOLD=0.02         # Max tasa de fallback a 0.5 permitida (0 = desactiva)
 
 # DEV_MODE: subset con gold docs garantizados
 DEV_MODE=false
@@ -176,6 +186,8 @@ Ver [`CLAUDE.md`](CLAUDE.md) para convenciones, divergencias con el paper, deuda
 **DTm-62/63/72/73/82/83:** Conditional fusion, eviction mejorada, BFS weighted, co-occurrence bridging, mypy zero errors, eliminacion HYBRID_PLUS.
 
 **Audit Fases 1-5:** 8 bugfixes, 48 tests nuevos, DAM-4 LLM synthesis, eviction con score compuesto. 447 tests, 0 fallos.
+
+**Post-refactor (abril 2026):** instrumentacion de tasa de fallback del LLM judge (deuda #4, +19 tests, threshold enforcement via `JUDGE_FALLBACK_THRESHOLD`) + capa de synthesis KG en generacion (divergencia LightRAG #2, +13 tests, prompt query-aware con citas `[ref:N]`, faithfulness contra structured_context original para penalizar hallucinations de la propia synthesis). Todas las divergencias arquitectonicas con el paper (#4+5, #6, #7, #2) resueltas.
 
 80+ issues resueltos. Ver historial git.
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -124,7 +124,8 @@ loader._manifest = None
 | test_metrics_reference_based.py | shared/metrics.py | 15 | normalize_text, f1_score, exact_match, accuracy |
 | test_semantic_similarity.py | shared/metrics.py | 9 | semantic_similarity coseno, vector cero, empty input, numpy guard |
 | test_dt6_context_truncation.py | shared/metrics.py | 3 | context pass-through sync/async, empty context |
-| test_dt9_extract_score_fallback.py | shared/metrics.py | 6 | _extract_score_fallback regex |
+| test_dt9_extract_score_fallback.py | shared/metrics.py | 21 | _extract_score_fallback regex |
+| test_judge_fallback_tracker.py | shared/metrics.py, sandbox_mteb/evaluator.py | 19 | _JudgeFallbackTracker, get_judge_fallback_stats, max_judge_default_return_rate, _validate_judge_fallback_threshold |
 | test_llm.py | shared/llm.py | 16 | LLMMetrics, thinking tags, invoke_async, load_embedding_model, retry |
 | test_knowledge_graph.py | shared/retrieval/lightrag/knowledge_graph.py | 65 | CRUD, BFS weighted, keywords, persistence, VDB, stats, eviction, co-occurrence |
 | test_triplet_extractor.py | shared/retrieval/lightrag/triplet_extractor.py | 36 | parsing, validation, batch, stats |
@@ -156,6 +157,7 @@ loader._manifest = None
 | test_dtm38_strategy_guardrail.py | sandbox_mteb/retrieval_executor.py, result_builder.py | 8 | strategy mismatch, config_snapshot |
 | test_dtm5_12_13_secondary_metric_errors.py | sandbox_mteb/generation_executor.py | 3 | secondary metric errors |
 | test_generation_executor.py | sandbox_mteb/generation_executor.py | 8 | generation async, metrics HYBRID, structured context, batch |
+| test_kg_synthesis.py | sandbox_mteb/generation_executor.py | 13 | _synthesize_kg_context_async gating, faithfulness-against-structured, graceful fallback (error/empty/oversized/timeout), _KGSynthesisTracker |
 | test_run_cli.py | sandbox_mteb/run.py | 11 | parse_args, setup_logging, main (dry-run, full, errors) |
 | test_preflight.py | sandbox_mteb/preflight.py | 8 | _check wrapper, dependencies, lock_file, config, main |
 | test_checkpoint.py | sandbox_mteb/checkpoint.py | 11 | save/load/delete checkpoint |
@@ -187,7 +189,7 @@ loader._manifest = None
 
 1. **Atributo nuevo en clase con `object.__new__()`**: actualizar TODOS los helpers listados arriba. Buscar con `grep -r "object.__new__(ClassName)" tests/`
 2. **Nuevo campo en RetrievalConfig**: propagado automaticamente via `RetrievalConfig()` default. Sin accion en tests salvo que el field necesite valor no-default
-3. **Nuevo campo en MTEBConfig**: actualizar helpers `_make_config()` en test_dtm4_subset_selection.py, test_embedding_service.py, test_pipeline_e2e.py si el field es required
+3. **Nuevo campo en MTEBConfig**: actualizar helpers `_make_config()` en test_dtm4_subset_selection.py, test_embedding_service.py, test_pipeline_e2e.py si el field es required. Ejemplos de campos recientes: `judge_fallback_threshold` (deuda #4), `kg_synthesis_enabled`/`kg_synthesis_max_chars`/`kg_synthesis_timeout_s` (divergencia LightRAG #2) — todos tienen defaults, no requieren tocar helpers
 4. **Nuevo campo en QueryRetrievalDetail o QueryEvaluationResult**: actualizar `_make_qr()` en test_checkpoint.py si el field es required
 5. **Import de botocore.exceptions**: nunca directo en tests. Usar `_FakeClientError` + `@patch`
 6. **Cada assertion debe usar `assert`**: nunca dejar expresiones booleanas sueltas (`x is None` sin assert)

--- a/sandbox_mteb/config.py
+++ b/sandbox_mteb/config.py
@@ -112,6 +112,22 @@ class MTEBConfig:
     # subir durante iteracion, bajar antes del experimento 3.
     judge_fallback_threshold: float = 0.02
 
+    # Synthesis de contexto KG en generacion (divergencia LightRAG #2).
+    # Cuando hay datos KG presentes (entidades o relaciones del KG) y esta
+    # flag esta activa, el contexto multi-seccion (entidades + relaciones +
+    # chunks) se reescribe como narrativa coherente via LLM ANTES de la
+    # generacion final. Faithfulness se sigue evaluando contra el contexto
+    # estructurado original (no contra la narrativa), para que cualquier
+    # alucinacion introducida por la propia synthesis sea penalizada.
+    # Solo aplica a LIGHT_RAG (SIMPLE_VECTOR no produce datos KG).
+    kg_synthesis_enabled: bool = True
+    # Limite de output de la synthesis en caracteres. Si 0, usa el mismo
+    # limite que la generacion (max_context_chars resuelto en runtime).
+    kg_synthesis_max_chars: int = 0
+    # Timeout dedicado para la llamada de synthesis (1 LLM call extra).
+    # Si se supera, se hace fallback al contexto estructurado original.
+    kg_synthesis_timeout_s: float = 30.0
+
     @classmethod
     def from_env(cls, env_path: str = ".env") -> "MTEBConfig":
         """Construye config completa desde .env.
@@ -136,6 +152,9 @@ class MTEBConfig:
             dev_queries=_env_int("DEV_QUERIES", 200),
             dev_corpus_size=_env_int("DEV_CORPUS_SIZE", 4000),
             judge_fallback_threshold=_env_float("JUDGE_FALLBACK_THRESHOLD", 0.02),
+            kg_synthesis_enabled=_env_bool("KG_SYNTHESIS_ENABLED", True),
+            kg_synthesis_max_chars=_env_int("KG_SYNTHESIS_MAX_CHARS", 0),
+            kg_synthesis_timeout_s=_env_float("KG_SYNTHESIS_TIMEOUT_S", 30.0),
         )
 
         errors = config.validate()
@@ -199,6 +218,17 @@ class MTEBConfig:
                 "debe estar en [0.0, 1.0] (0.0 desactiva la validacion)"
             )
 
+        if self.kg_synthesis_max_chars < 0:
+            errors.append(
+                f"KG_SYNTHESIS_MAX_CHARS={self.kg_synthesis_max_chars} "
+                "debe ser >= 0 (0 = usar max_context_chars del run)"
+            )
+        if self.kg_synthesis_timeout_s <= 0:
+            errors.append(
+                f"KG_SYNTHESIS_TIMEOUT_S={self.kg_synthesis_timeout_s} "
+                "debe ser > 0"
+            )
+
         return errors
 
     def ensure_directories(self) -> None:
@@ -228,6 +258,13 @@ class MTEBConfig:
                 f"  KG mode:    {self.retrieval.lightrag_mode}",
                 f"  KG tokens:  extraction={self.retrieval.kg_extraction_max_tokens}, keyword={self.retrieval.kg_keyword_max_tokens}",
                 f"  KG batch:   {self.retrieval.kg_batch_docs_per_call} docs/call",
+                f"  KG synth:   {'ON' if self.kg_synthesis_enabled else 'OFF'}"
+                + (
+                    f" (max_chars={self.kg_synthesis_max_chars or 'auto'}, "
+                    f"timeout={self.kg_synthesis_timeout_s}s)"
+                    if self.kg_synthesis_enabled
+                    else ""
+                ),
                 f"  WARNING:    LIGHT_RAG requiere ~1 llamada LLM por documento "
                 f"para construir el knowledge graph (concurrencia={self.infra.nim_max_concurrent})",
             ])
@@ -261,8 +298,65 @@ GENERATION_PROMPTS: Dict[str, Dict[str, str]] = {
 }
 
 
+# =========================================================================
+# PROMPT DE SYNTHESIS DE CONTEXTO KG (divergencia LightRAG #2)
+# =========================================================================
+# El system prompt acepta un placeholder {max_chars} que se rellena en
+# runtime con kg_synthesis_max_chars (o max_context_chars si es 0).
+# El user prompt recibe la pregunta y el contexto multi-seccion ya
+# formateado por format_structured_context().
+
+KG_SYNTHESIS_SYSTEM_PROMPT = """You are a context-synthesis assistant for a Retrieval-Augmented Generation \
+(RAG) system. A downstream model will answer the user's QUESTION using ONLY \
+the narrative you produce, so your output must contain every piece of \
+evidence relevant to the QUESTION and nothing else.
+
+INPUT FORMAT
+You will receive:
+- QUESTION: the user's question.
+- Knowledge Graph Data (Entity): JSON list of entities with descriptions.
+- Knowledge Graph Data (Relationship): JSON list of (source, target, \
+relation) triples with descriptions.
+- Document Chunks: JSON list of {{"reference_id": N, "content": "..."}} \
+passages from the corpus.
+Any of the KG sections may be empty.
+
+YOUR TASK
+Rewrite the input as a coherent narrative (one or a few paragraphs) that:
+- Connects the entities and relationships to the textual evidence.
+- Focuses on information relevant to the QUESTION.
+- Preserves chunk provenance: when you state a fact taken from a chunk, \
+cite it inline as [ref:N] using the chunk's reference_id.
+
+STRICT RULES
+1. Use ONLY information present in the input sections. Do NOT introduce \
+facts, entities, dates, or relationships that are not explicitly stated. \
+Direct inferences from the input are allowed.
+2. Do NOT answer the QUESTION. Synthesize the supporting context only.
+3. If the KG data and the chunks disagree, prefer the chunks (the chunks \
+are the source; the KG is derived from them by an extractor that may have \
+errored).
+4. If a section is empty, omit it from the narrative.
+5. Keep your output under {max_chars} characters. Prefer clarity over \
+completeness when the limit is tight.
+
+OUTPUT
+Plain prose. No headings, no bullet lists, no JSON. Use [ref:N] inline \
+to cite chunk content."""
+
+
+KG_SYNTHESIS_USER_TEMPLATE = """QUESTION:
+{query}
+
+{structured_context}
+
+Now produce the synthesis narrative."""
+
+
 __all__ = [
     "MTEBConfig",
     "MinIOStorageConfig",
     "GENERATION_PROMPTS",
+    "KG_SYNTHESIS_SYSTEM_PROMPT",
+    "KG_SYNTHESIS_USER_TEMPLATE",
 ]

--- a/sandbox_mteb/config.py
+++ b/sandbox_mteb/config.py
@@ -102,6 +102,16 @@ class MTEBConfig:
     dev_queries: int = 200
     dev_corpus_size: int = 4000
 
+    # Umbral de tasa de fallback del LLM judge (deuda tecnica #4).
+    # Si en el run la proporcion de scores devueltos como default 0.5
+    # (el judge no pudo producir JSON parseable ni score via regex) supera
+    # este umbral para CUALQUIER metrica del judge, el run se marca como
+    # fallido al final. Protege metricas como faithfulness del sesgo
+    # silencioso hacia el centro. 0.0 desactiva la validacion (no fallar).
+    # Default 0.02 (2%) — razonable para judge modernos bien prompteados;
+    # subir durante iteracion, bajar antes del experimento 3.
+    judge_fallback_threshold: float = 0.02
+
     @classmethod
     def from_env(cls, env_path: str = ".env") -> "MTEBConfig":
         """Construye config completa desde .env.
@@ -125,6 +135,7 @@ class MTEBConfig:
             dev_mode=_env_bool("DEV_MODE", False),
             dev_queries=_env_int("DEV_QUERIES", 200),
             dev_corpus_size=_env_int("DEV_CORPUS_SIZE", 4000),
+            judge_fallback_threshold=_env_float("JUDGE_FALLBACK_THRESHOLD", 0.02),
         )
 
         errors = config.validate()
@@ -181,6 +192,12 @@ class MTEBConfig:
                 errors.append(f"DEV_QUERIES={self.dev_queries} debe ser > 0 cuando DEV_MODE=true")
             if self.dev_corpus_size <= 0:
                 errors.append(f"DEV_CORPUS_SIZE={self.dev_corpus_size} debe ser > 0 cuando DEV_MODE=true")
+
+        if not 0.0 <= self.judge_fallback_threshold <= 1.0:
+            errors.append(
+                f"JUDGE_FALLBACK_THRESHOLD={self.judge_fallback_threshold} "
+                "debe estar en [0.0, 1.0] (0.0 desactiva la validacion)"
+            )
 
         return errors
 

--- a/sandbox_mteb/env.example
+++ b/sandbox_mteb/env.example
@@ -78,6 +78,18 @@ GENERATION_ENABLED=true
 GENERATION_MAX_CONTEXT_CHARS=0
 
 # =========================================================================
+# LLM JUDGE INSTRUMENTATION (deuda tecnica #4)
+# =========================================================================
+# El LLM judge de faithfulness/answer_relevance puede fallar a producir
+# JSON parseable; en ese caso se intenta extraer el score via regex y,
+# si tambien falla, se devuelve 0.5 por defecto (sesga metricas hacia
+# el centro). El run se marca como fallido si la tasa de "default_returns"
+# supera este umbral para cualquier metrica del judge.
+# 0.0 desactiva la validacion (no fallar nunca).
+# Default 0.02 (2%) — razonable para judges modernos bien prompteados.
+JUDGE_FALLBACK_THRESHOLD=0.02
+
+# =========================================================================
 # JERARQUIA DE LIMITES DE TOKENS/CARACTERES
 # =========================================================================
 # El pipeline aplica 3 limites en distintas fases. De mayor a menor:
@@ -185,6 +197,28 @@ KG_CACHE_DIR=
 # Incrementa calidad del KG pero consume LLM calls adicionales.
 KG_DESCRIPTION_SYNTHESIS=false
 KG_SYNTHESIS_CHAR_THRESHOLD=200
+
+# =========================================================================
+# KG CONTEXT SYNTHESIS (divergencia LightRAG #2, solo LIGHT_RAG)
+# =========================================================================
+# Cuando hay datos KG en el retrieval (entidades/relaciones), el contexto
+# multi-seccion (entidades + relaciones + chunks) se reescribe como
+# narrativa coherente via LLM ANTES de la generacion final. El prompt es
+# query-aware y preserva citas [ref:N] a los chunks originales.
+# Faithfulness se sigue evaluando contra el contexto estructurado original,
+# NO contra la narrativa, para penalizar cualquier alucinacion introducida
+# por la propia synthesis.
+# Degradacion graceful: error LLM / vacio / timeout / oversize -> fallback
+# al contexto estructurado. Stats en config_snapshot._runtime.kg_synthesis_stats.
+KG_SYNTHESIS_ENABLED=true
+
+# Limite de output de la synthesis en caracteres.
+# 0 = usar el mismo limite que la generacion (max_context_chars del run).
+KG_SYNTHESIS_MAX_CHARS=0
+
+# Timeout dedicado para la llamada de synthesis (1 LLM call extra por query).
+# Si se supera, fallback al contexto estructurado.
+KG_SYNTHESIS_TIMEOUT_S=30.0
 
 # =========================================================================
 # PATHS (relativos al directorio de ejecucion)

--- a/sandbox_mteb/evaluator.py
+++ b/sandbox_mteb/evaluator.py
@@ -29,7 +29,12 @@ from shared.types import (
     get_dataset_config,
 )
 from shared.llm import AsyncLLMService, load_embedding_model, run_sync
-from shared.metrics import MetricsCalculator
+from shared.metrics import (
+    MetricsCalculator,
+    get_judge_fallback_stats,
+    max_judge_default_return_rate,
+    reset_judge_fallback_stats,
+)
 from shared.retrieval import get_retriever, RetrievalStrategy
 from shared.retrieval.core import BaseRetriever
 from shared.retrieval.reranker import CrossEncoderReranker, HAS_NVIDIA_RERANK
@@ -92,6 +97,11 @@ class MTEBEvaluator:
 
         self._log_run_start(run_id)
 
+        # Deuda tecnica #4: resetear tracker del judge al inicio de cada run
+        # para que las tasas reflejen solo este run y no estado acumulado
+        # de runs previos en el mismo proceso.
+        reset_judge_fallback_stats()
+
         try:
             # 1. Inicializar componentes
             self._init_components()
@@ -126,6 +136,12 @@ class MTEBEvaluator:
             )
 
             self._log_run_complete(run_id, elapsed, evaluation_run)
+
+            # 6. Validar tasa de fallback del judge (deuda tecnica #4).
+            # Se hace DESPUES de construir el run para que las stats queden
+            # persistidas en `config_snapshot._runtime` incluso si fallamos.
+            self._validate_judge_fallback_threshold(run_id)
+
             return evaluation_run
 
         except Exception as e:
@@ -190,6 +206,20 @@ class MTEBEvaluator:
             f"Hit@5={evaluation_run.avg_hit_rate_at_5:.4f} | "
             f"MRR={evaluation_run.avg_mrr:.4f}"
         )
+
+        # Deuda tecnica #4: reporte visible de tasa de fallback del judge.
+        judge_stats = get_judge_fallback_stats()
+        if judge_stats:
+            for metric_name, s in judge_stats.items():
+                logger.info(
+                    "  Judge fallback (%s): invocations=%d, "
+                    "parse_failure_rate=%.2f%%, default_return_rate=%.2f%%",
+                    metric_name,
+                    s["invocations"],
+                    s["parse_failure_rate"] * 100,
+                    s["default_return_rate"] * 100,
+                )
+
         structured_log(
             "run_complete",
             run_id=run_id,
@@ -203,7 +233,45 @@ class MTEBEvaluator:
                 if evaluation_run.avg_generation_score is not None
                 else None
             ),
+            judge_fallback_stats=judge_stats,
         )
+
+    def _validate_judge_fallback_threshold(self, run_id: str) -> None:
+        """Falla el run si algun judge metric supera el threshold configurado.
+
+        Deuda tecnica #4: protege el experimento 3 (y cualquier run futuro
+        sobre corpus especializados) de reportar deltas artefacto causados
+        por el judge devolviendo 0.5 por defecto. Las stats ya estan
+        persistidas en `evaluation_run.config_snapshot._runtime` antes de
+        llegar aqui, asi que el usuario siempre puede inspeccionarlas.
+        """
+        threshold = self.config.judge_fallback_threshold
+        if threshold <= 0.0:
+            return  # Validacion desactivada explicitamente
+
+        stats = get_judge_fallback_stats()
+        worst_metric, worst_rate = max_judge_default_return_rate(stats)
+
+        if worst_metric is not None and worst_rate > threshold:
+            msg = (
+                f"Tasa de fallback del judge excedida: metrica "
+                f"'{worst_metric}' devolvio 0.5 por defecto en "
+                f"{worst_rate * 100:.2f}% de invocaciones "
+                f"(umbral={threshold * 100:.2f}%). Las metricas del judge "
+                f"estan sesgadas hacia el centro y los deltas entre "
+                f"estrategias no son interpretables. "
+                f"Sube JUDGE_FALLBACK_THRESHOLD (no recomendado) o "
+                f"investiga por que el judge no produce JSON parseable."
+            )
+            logger.error(msg)
+            structured_log(
+                "run_judge_threshold_exceeded",
+                run_id=run_id,
+                metric=worst_metric,
+                default_return_rate=round(worst_rate, 4),
+                threshold=threshold,
+            )
+            raise RuntimeError(msg)
 
     # -----------------------------------------------------------------
     # INICIALIZACION

--- a/sandbox_mteb/evaluator.py
+++ b/sandbox_mteb/evaluator.py
@@ -51,7 +51,12 @@ from .checkpoint import (
 from .result_builder import build_run
 from .subset_selection import select_subset_dev, select_subset_standard
 from .retrieval_executor import RetrievalExecutor, format_context
-from .generation_executor import GenerationExecutor, GenMetricsResult
+from .generation_executor import (
+    GenerationExecutor,
+    GenMetricsResult,
+    get_kg_synthesis_stats,
+    reset_kg_synthesis_stats,
+)
 from .embedding_service import batch_embed_queries, resolve_max_context_chars
 
 logger = logging.getLogger(__name__)
@@ -101,6 +106,8 @@ class MTEBEvaluator:
         # para que las tasas reflejen solo este run y no estado acumulado
         # de runs previos en el mismo proceso.
         reset_judge_fallback_stats()
+        # Divergencia LightRAG #2: resetear tambien el tracker de synthesis.
+        reset_kg_synthesis_stats()
 
         try:
             # 1. Inicializar componentes
@@ -220,6 +227,22 @@ class MTEBEvaluator:
                     s["default_return_rate"] * 100,
                 )
 
+        # Divergencia LightRAG #2: reporte de stats del KG synthesis.
+        synthesis_stats = get_kg_synthesis_stats()
+        if synthesis_stats["invocations"] > 0:
+            logger.info(
+                "  KG synthesis: invocations=%d, successes=%d, "
+                "errors=%d, empty=%d, truncations=%d, timeouts=%d, "
+                "fallback_rate=%.2f%%",
+                synthesis_stats["invocations"],
+                synthesis_stats["successes"],
+                synthesis_stats["errors"],
+                synthesis_stats["empty_returns"],
+                synthesis_stats["truncations"],
+                synthesis_stats["timeouts"],
+                synthesis_stats["fallback_rate"] * 100,
+            )
+
         structured_log(
             "run_complete",
             run_id=run_id,
@@ -234,6 +257,7 @@ class MTEBEvaluator:
                 else None
             ),
             judge_fallback_stats=judge_stats,
+            kg_synthesis_stats=synthesis_stats,
         )
 
     def _validate_judge_fallback_threshold(self, run_id: str) -> None:
@@ -332,11 +356,21 @@ class MTEBEvaluator:
         if self.config.generation_enabled and self._llm_service:
             self._max_context_chars = resolve_max_context_chars(self.config)
 
+            # Synthesis del contexto KG: solo tiene sentido para LIGHT_RAG
+            # (SIMPLE_VECTOR no produce kg_entities/kg_relations).
+            kg_synthesis_enabled = (
+                self.config.kg_synthesis_enabled
+                and self.config.retrieval.strategy == RetrievalStrategy.LIGHT_RAG
+            )
+
             # Generation executor
             self._generation_executor = GenerationExecutor(
                 llm_service=self._llm_service,
                 metrics_calculator=self._metrics_calculator,
                 max_context_chars=self._max_context_chars,
+                kg_synthesis_enabled=kg_synthesis_enabled,
+                kg_synthesis_max_chars=self.config.kg_synthesis_max_chars,
+                kg_synthesis_timeout_s=self.config.kg_synthesis_timeout_s,
             )
 
     # -----------------------------------------------------------------

--- a/sandbox_mteb/generation_executor.py
+++ b/sandbox_mteb/generation_executor.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
+from collections import Counter
 from typing import Any, Dict, List, Optional, Tuple
 
 from shared.types import (
@@ -23,10 +25,85 @@ from shared.llm import AsyncLLMService
 from shared.metrics import MetricsCalculator, MetricResult
 
 from shared.constants import GENERATION_QUERY_TIMEOUT_S
-from .config import GENERATION_PROMPTS
+from .config import (
+    GENERATION_PROMPTS,
+    KG_SYNTHESIS_SYSTEM_PROMPT,
+    KG_SYNTHESIS_USER_TEMPLATE,
+)
 from .retrieval_executor import format_context, format_structured_context
 
 logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Tracker de KG synthesis (divergencia LightRAG #2).
+#
+# La synthesis es un paso opcional que reescribe el contexto multi-seccion
+# como narrativa coherente. Si falla, hacemos fallback al contexto
+# estructurado y el run continua. El tracker permite auditar si el feature
+# esta funcionando correctamente o degradando silenciosamente.
+#
+# Eventos:
+#   - invocations: queries donde se intento la synthesis (KG data + flag on).
+#   - successes: synthesis devolvio narrativa no vacia dentro del budget.
+#   - errors: el LLM lanzo excepcion.
+#   - empty_returns: el LLM devolvio string vacio o solo whitespace.
+#   - truncations: la respuesta excedio max_chars y fue truncada.
+#   - timeouts: la llamada excedio kg_synthesis_timeout_s.
+# -----------------------------------------------------------------------------
+
+
+class _KGSynthesisTracker:
+    """Contador thread-safe de eventos de KG synthesis."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._counters: Counter = Counter()
+
+    def record(self, event: str) -> None:
+        with self._lock:
+            self._counters[event] += 1
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            n = self._counters.get("invocations", 0)
+            fallbacks = (
+                self._counters.get("errors", 0)
+                + self._counters.get("empty_returns", 0)
+                + self._counters.get("timeouts", 0)
+            )
+            return {
+                "invocations": n,
+                "successes": self._counters.get("successes", 0),
+                "errors": self._counters.get("errors", 0),
+                "empty_returns": self._counters.get("empty_returns", 0),
+                "truncations": self._counters.get("truncations", 0),
+                "timeouts": self._counters.get("timeouts", 0),
+                "fallback_rate": (fallbacks / n) if n else 0.0,
+            }
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counters.clear()
+
+
+_kg_synthesis_tracker = _KGSynthesisTracker()
+
+
+def get_kg_synthesis_stats() -> Dict[str, Any]:
+    """Snapshot del tracker de KG synthesis (divergencia LightRAG #2).
+
+    Claves devueltas:
+      - invocations: queries donde se intento la synthesis
+      - successes, errors, empty_returns, truncations, timeouts
+      - fallback_rate: (errors + empty_returns + timeouts) / invocations
+    """
+    return _kg_synthesis_tracker.snapshot()
+
+
+def reset_kg_synthesis_stats() -> None:
+    """Resetea contadores. Llamar al inicio de cada run."""
+    _kg_synthesis_tracker.reset()
 
 
 class GenMetricsResult:
@@ -55,11 +132,21 @@ class GenerationExecutor:
         metrics_calculator: MetricsCalculator,
         max_context_chars: int,
         query_timeout_s: float = GENERATION_QUERY_TIMEOUT_S,
+        kg_synthesis_enabled: bool = False,
+        kg_synthesis_max_chars: int = 0,
+        kg_synthesis_timeout_s: float = 30.0,
     ):
         self._llm_service = llm_service
         self._metrics_calculator = metrics_calculator
         self._max_context_chars = max_context_chars
         self._query_timeout_s = query_timeout_s
+        self._kg_synthesis_enabled = kg_synthesis_enabled
+        # Si max_chars es 0, usar el mismo limite que la generacion.
+        self._kg_synthesis_max_chars = (
+            kg_synthesis_max_chars if kg_synthesis_max_chars > 0
+            else max_context_chars
+        )
+        self._kg_synthesis_timeout_s = kg_synthesis_timeout_s
 
     async def batch_generate_and_evaluate(
         self,
@@ -90,11 +177,12 @@ class GenerationExecutor:
         # Divergencia #7: modo LightRAG determina presupuestos por seccion.
         kg_entities = retrieval_detail.retrieval_metadata.get("kg_entities")
         kg_relations = retrieval_detail.retrieval_metadata.get("kg_relations")
-        if kg_entities or kg_relations:
+        has_kg_data = bool(kg_entities or kg_relations)
+        if has_kg_data:
             lightrag_mode = retrieval_detail.retrieval_metadata.get(
                 "lightrag_mode", "hybrid"
             )
-            context = format_structured_context(
+            structured_context = format_structured_context(
                 retrieval_detail.get_generation_contents(),
                 kg_entities or [],
                 kg_relations or [],
@@ -102,22 +190,37 @@ class GenerationExecutor:
                 mode=lightrag_mode,
             )
         else:
-            context = format_context(
+            structured_context = format_context(
                 retrieval_detail.get_generation_contents(),
                 self._max_context_chars,
             )
 
-        # 1. Generacion async
+        # Divergencia LightRAG #2: synthesis del contexto KG.
+        # Solo si hay datos KG y la flag esta activa. Si la synthesis falla,
+        # degradamos al contexto estructurado original (no rompemos el run).
+        # `generation_context` es lo que ve el LLM generador.
+        # `structured_context` es siempre el original; faithfulness se evalua
+        # contra este para penalizar cualquier alucinacion introducida por
+        # la propia capa de synthesis.
+        if has_kg_data and self._kg_synthesis_enabled:
+            generation_context = await self._synthesize_kg_context_async(
+                query.query_text, structured_context
+            )
+        else:
+            generation_context = structured_context
+
+        # 1. Generacion async (usa el contexto sintetizado si lo hay)
         generation = await self._execute_generation_async(
-            query.query_text, context, dataset_name
+            query.query_text, generation_context, dataset_name
         )
 
-        # 2. Metricas async
+        # 2. Metricas async (faithfulness se evalua contra structured_context
+        # original, no contra la narrativa del synthesis)
         primary_result, secondary_results = await self._calculate_metrics_async(
             generated=generation.generated_response,
             expected_answer=query.expected_answer,
             answer_type=query.answer_type,
-            context=context,
+            context=structured_context,
             query_text=query.query_text,
             dataset_type=ds_config["type"],
             dataset_name=dataset_name,
@@ -158,6 +261,77 @@ class GenerationExecutor:
         except Exception as e:
             logger.warning(f"Error generacion async: {e}")
             return GenerationResult(f"[ERROR: {e}]", 0.0)
+
+    async def _synthesize_kg_context_async(
+        self,
+        query_text: str,
+        structured_context: str,
+    ) -> str:
+        """Reescribe el contexto KG multi-seccion como narrativa coherente.
+
+        Divergencia LightRAG #2. Usa el LLM (`self._llm_service`) con un
+        prompt query-aware que pide narrativa con citas [ref:N] preservadas.
+
+        Degradacion graceful: si el LLM falla, devuelve string vacio o
+        excede el budget, hacemos fallback al `structured_context` original.
+        El run nunca se rompe por culpa de la synthesis. Todos los modos de
+        fallo se contabilizan en `_kg_synthesis_tracker`.
+
+        Returns:
+            Narrativa sintetizada (puede estar truncada al budget) o el
+            structured_context original como fallback.
+        """
+        _kg_synthesis_tracker.record("invocations")
+
+        max_chars = self._kg_synthesis_max_chars
+        system_prompt = KG_SYNTHESIS_SYSTEM_PROMPT.format(max_chars=max_chars)
+        user_prompt = KG_SYNTHESIS_USER_TEMPLATE.format(
+            query=query_text,
+            structured_context=structured_context,
+        )
+
+        try:
+            response = await asyncio.wait_for(
+                self._llm_service.invoke_async(
+                    user_prompt, system_prompt=system_prompt
+                ),
+                timeout=self._kg_synthesis_timeout_s,
+            )
+        except asyncio.TimeoutError:
+            _kg_synthesis_tracker.record("timeouts")
+            logger.warning(
+                "KG synthesis timeout (%.1fs) para query '%s...'; "
+                "usando contexto estructurado.",
+                self._kg_synthesis_timeout_s,
+                query_text[:60],
+            )
+            return structured_context
+        except Exception as e:
+            _kg_synthesis_tracker.record("errors")
+            logger.warning(
+                "KG synthesis error: %s (query: '%s...'); "
+                "usando contexto estructurado.",
+                e,
+                query_text[:60],
+            )
+            return structured_context
+
+        narrative = str(response).strip()
+        if not narrative:
+            _kg_synthesis_tracker.record("empty_returns")
+            logger.warning(
+                "KG synthesis devolvio respuesta vacia para query '%s...'; "
+                "usando contexto estructurado.",
+                query_text[:60],
+            )
+            return structured_context
+
+        if len(narrative) > max_chars:
+            _kg_synthesis_tracker.record("truncations")
+            narrative = narrative[:max_chars]
+
+        _kg_synthesis_tracker.record("successes")
+        return narrative
 
     async def _calculate_metrics_async(
         self,
@@ -265,4 +439,9 @@ class GenerationExecutor:
         return primary, secondary
 
 
-__all__ = ["GenerationExecutor", "GenMetricsResult"]
+__all__ = [
+    "GenerationExecutor",
+    "GenMetricsResult",
+    "get_kg_synthesis_stats",
+    "reset_kg_synthesis_stats",
+]

--- a/sandbox_mteb/result_builder.py
+++ b/sandbox_mteb/result_builder.py
@@ -22,6 +22,7 @@ from shared.metrics import get_judge_fallback_stats
 from shared.retrieval import RetrievalStrategy
 
 from .config import MTEBConfig
+from .generation_executor import get_kg_synthesis_stats
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,10 @@ def build_run(
         # Deuda tecnica #4: tasa de fallback del LLM judge por metrica.
         # default_return_rate elevado => metricas del judge sesgadas a 0.5.
         "judge_fallback_stats": judge_fallback_stats,
+        # Divergencia LightRAG #2: stats de la capa de synthesis del KG.
+        # invocations==0 => synthesis no se intento (no LIGHT_RAG, sin KG
+        # data, o flag desactivada).
+        "kg_synthesis_stats": get_kg_synthesis_stats(),
     }
 
     return EvaluationRun(

--- a/sandbox_mteb/result_builder.py
+++ b/sandbox_mteb/result_builder.py
@@ -18,6 +18,7 @@ from shared.types import (
     QueryEvaluationResult,
     LoadedDataset,
 )
+from shared.metrics import get_judge_fallback_stats
 from shared.retrieval import RetrievalStrategy
 
 from .config import MTEBConfig
@@ -137,6 +138,7 @@ def build_run(
     # Config snapshot: serializacion completa para reproducibilidad post-hoc
     config_snapshot = _serialize_config(config)
     # Campos derivados del run (no en config)
+    judge_fallback_stats = get_judge_fallback_stats()
     config_snapshot["_runtime"] = {
         "max_context_chars": max_context_chars,
         "rerank_failures": rerank_failures if config.reranker.enabled else None,
@@ -150,6 +152,9 @@ def build_run(
             if strategy_mismatches == 0
             else "FALLBACK_SIMPLE_VECTOR"
         ),
+        # Deuda tecnica #4: tasa de fallback del LLM judge por metrica.
+        # default_return_rate elevado => metricas del judge sesgadas a 0.5.
+        "judge_fallback_stats": judge_fallback_stats,
     }
 
     return EvaluationRun(

--- a/shared/metrics.py
+++ b/shared/metrics.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import re
 import string
+import threading
 import unicodedata
 from collections import Counter
 from dataclasses import dataclass
@@ -354,6 +355,122 @@ def semantic_similarity(
 # SECCION 4: METRICAS SIN REFERENCIA (LLM-Judge)
 # =============================================================================
 
+# -----------------------------------------------------------------------------
+# Tracker de tasa de fallback del LLM judge (deuda tecnica #4)
+#
+# Contabiliza, por tipo de metrica, la proporcion de invocaciones donde el
+# judge no pudo producir un score estructurado y tuvimos que recurrir a
+# parsing regex o, peor, al default 0.5.
+#
+# Tres eventos rastreados:
+#   - invocations: llamadas totales al judge (denominador).
+#   - parse_failures: respuesta no parseable como JSON, se delega a regex.
+#   - default_returns: regex tambien fallo, devolvimos 0.5 por defecto.
+#     Este es el evento critico — sesga metricas silenciosamente hacia el
+#     centro y puede comprimir deltas entre estrategias (especialmente en
+#     faithfulness, que evalua alucinacion en el experimento 3).
+#
+# Thread-safe: el judge se invoca concurrentemente via asyncio / threads.
+# -----------------------------------------------------------------------------
+
+
+class _JudgeFallbackTracker:
+    """Contador thread-safe de eventos de fallback del judge por metrica."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._invocations: Counter = Counter()
+        self._parse_failures: Counter = Counter()
+        self._default_returns: Counter = Counter()
+
+    def record_invocation(self, metric_type: MetricType) -> None:
+        with self._lock:
+            self._invocations[metric_type.value] += 1
+
+    def record_parse_failure(self, metric_type: MetricType) -> None:
+        with self._lock:
+            self._parse_failures[metric_type.value] += 1
+
+    def record_default_return(self, metric_type: MetricType) -> None:
+        with self._lock:
+            self._default_returns[metric_type.value] += 1
+
+    def snapshot(self) -> Dict[str, Dict[str, Any]]:
+        """Snapshot por metrica con contadores absolutos y tasas."""
+        with self._lock:
+            metric_names = (
+                set(self._invocations)
+                | set(self._parse_failures)
+                | set(self._default_returns)
+            )
+            result: Dict[str, Dict[str, Any]] = {}
+            for name in metric_names:
+                n = self._invocations[name]
+                result[name] = {
+                    "invocations": n,
+                    "parse_failures": self._parse_failures[name],
+                    "default_returns": self._default_returns[name],
+                    "parse_failure_rate": (
+                        self._parse_failures[name] / n if n else 0.0
+                    ),
+                    "default_return_rate": (
+                        self._default_returns[name] / n if n else 0.0
+                    ),
+                }
+            return result
+
+    def reset(self) -> None:
+        with self._lock:
+            self._invocations.clear()
+            self._parse_failures.clear()
+            self._default_returns.clear()
+
+
+_judge_fallback_tracker = _JudgeFallbackTracker()
+
+
+def get_judge_fallback_stats() -> Dict[str, Dict[str, Any]]:
+    """Retorna snapshot del tracker de fallback del judge.
+
+    Cada clave es el nombre de una metrica (MetricType.value). Valores:
+      - invocations: llamadas totales al judge
+      - parse_failures: respuestas no parseables como JSON
+      - default_returns: casos donde se devolvio 0.5 por defecto
+      - parse_failure_rate, default_return_rate: ratios contra invocations
+
+    Uso tipico: inspeccionar tras un run para detectar degradacion del judge.
+    `default_return_rate` es la senal clave — valores altos indican que el
+    judge esta fallando a producir scores interpretables y las metricas
+    (especialmente faithfulness) estan sesgadas hacia 0.5.
+    """
+    return _judge_fallback_tracker.snapshot()
+
+
+def reset_judge_fallback_stats() -> None:
+    """Resetea contadores. Llamar al inicio de cada run de evaluacion."""
+    _judge_fallback_tracker.reset()
+
+
+def max_judge_default_return_rate(
+    stats: Dict[str, Dict[str, Any]],
+) -> Tuple[Optional[str], float]:
+    """Devuelve (nombre_metrica, tasa) con el mayor default_return_rate.
+
+    Util para validar un run contra un umbral. Si no hay invocaciones,
+    retorna (None, 0.0).
+    """
+    if not stats:
+        return (None, 0.0)
+    worst_metric: Optional[str] = None
+    worst_rate = 0.0
+    for name, s in stats.items():
+        rate = s.get("default_return_rate", 0.0)
+        if rate > worst_rate:
+            worst_rate = rate
+            worst_metric = name
+    return (worst_metric, worst_rate)
+
+
 # Prompts del sistema
 _FAITHFULNESS_SYSTEM_PROMPT = """You are an expert RAG system evaluator.
 Your task is to assess whether an ANSWER is derived EXCLUSIVELY from the
@@ -452,6 +569,7 @@ def _invoke_judge(
     metric_type: MetricType
 ) -> MetricResult:
     """Invoca LLM Judge sync y parsea respuesta JSON."""
+    _judge_fallback_tracker.record_invocation(metric_type)
     try:
         response = llm_judge.invoke(user_prompt, system_prompt=system_prompt)
         response_text = str(response).strip()
@@ -474,6 +592,7 @@ async def _invoke_judge_async(
     metric_type: MetricType
 ) -> MetricResult:
     """Version async de _invoke_judge. Usa invoke_async del LLM."""
+    _judge_fallback_tracker.record_invocation(metric_type)
     try:
         response = await llm_judge.invoke_async(
             user_prompt, system_prompt=system_prompt
@@ -512,16 +631,32 @@ def _parse_judge_result(response_text: str, metric_type: MetricType) -> MetricRe
             confidence=confidence
         )
     else:
-        score = _extract_score_fallback(response_text)
+        # Deuda tecnica #4: el JSON no parseo, caemos a regex. Esto ya
+        # es una senal de degradacion del judge.
+        _judge_fallback_tracker.record_parse_failure(metric_type)
+
+        score, was_default = _extract_score_fallback_with_status(response_text)
+        if was_default:
+            # Caso critico: ni JSON ni regex extrajeron score. 0.5 por
+            # defecto sesga metricas hacia el centro.
+            _judge_fallback_tracker.record_default_return(metric_type)
+            logger.warning(
+                "Score extraction fallback (%s): judge devolvio respuesta "
+                "no parseable y los regex fallaron; usando 0.5 por defecto. "
+                "Raw response (trunc): %r",
+                metric_type.value,
+                response_text[:200],
+            )
 
         return MetricResult(
             metric_type=metric_type,
             value=score,
             details={
                 "justification": "Formato no estructurado",
-                "raw_response": response_text[:500]
+                "raw_response": response_text[:500],
+                "fallback_default_used": was_default,
             },
-            confidence=0.4
+            confidence=0.2 if was_default else 0.4,
         )
 
 
@@ -548,8 +683,15 @@ def _parse_judge_response(response_text: str) -> Optional[Dict[str, Any]]:
     return None
 
 
-def _extract_score_fallback(response_text: str) -> float:
+def _extract_score_fallback_with_status(
+    response_text: str,
+) -> Tuple[float, bool]:
     """Extrae score numerico de respuesta no estructurada.
+
+    Devuelve (score, was_default): `was_default=True` si ningun regex
+    pudo extraer un valor y se devolvio 0.5 por defecto. Este flag permite
+    al caller distinguir "score extraido via regex" (senal debil pero real)
+    de "ningun score, devolvi el centro" (sesgo silencioso).
 
     FIX DT-9: Regex anterior capturaba parciales de numeros mayores.
     Ahora usa word boundaries y patrones explicitos:
@@ -568,7 +710,7 @@ def _extract_score_fallback(response_text: str) -> float:
             numerator = float(match.group(1))
             denominator = float(match.group(2))
             if denominator > 0:
-                return min(1.0, numerator / denominator)
+                return (min(1.0, numerator / denominator), False)
         except ValueError:
             pass
 
@@ -580,7 +722,7 @@ def _extract_score_fallback(response_text: str) -> float:
         try:
             value = float(match.group(1))
             if 0 <= value <= 1:
-                return value
+                return (value, False)
         except ValueError:
             pass
 
@@ -592,11 +734,17 @@ def _extract_score_fallback(response_text: str) -> float:
         try:
             value = int(match.group(1))
             if 1 <= value <= 10:
-                return value / 10
+                return (value / 10, False)
         except ValueError:
             pass
 
-    return 0.5
+    return (0.5, True)
+
+
+def _extract_score_fallback(response_text: str) -> float:
+    """Wrapper que descarta el status. Conservado para compat (tests DT-9)."""
+    score, _ = _extract_score_fallback_with_status(response_text)
+    return score
 
 
 # -- Funciones publicas LLM-Judge (sync) -----------------------------------

--- a/tests/test_judge_fallback_tracker.py
+++ b/tests/test_judge_fallback_tracker.py
@@ -1,0 +1,303 @@
+"""
+Tests deuda tecnica #4: instrumentacion de tasa de fallback del LLM judge.
+
+Verifica que el tracker contabiliza correctamente:
+  - invocaciones totales
+  - fallos de parseo JSON (parse_failures)
+  - retornos de 0.5 por defecto (default_returns, evento critico)
+y que max_judge_default_return_rate identifica la metrica peor.
+"""
+from __future__ import annotations
+
+import pytest
+
+from shared.metrics import (
+    MetricType,
+    _extract_score_fallback,
+    _extract_score_fallback_with_status,
+    _parse_judge_result,
+    get_judge_fallback_stats,
+    max_judge_default_return_rate,
+    reset_judge_fallback_stats,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_tracker():
+    """Cada test arranca con contadores limpios."""
+    reset_judge_fallback_stats()
+    yield
+    reset_judge_fallback_stats()
+
+
+# -----------------------------------------------------------------------------
+# _extract_score_fallback_with_status
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text,expected_score,expected_default", [
+    ("score: 0.85", 0.85, False),          # decimal extraido
+    ("I rate this 8/10", 0.8, False),      # fraccion extraida
+    ("score: 7", 0.7, False),              # int 1-10 normalizado
+    ("I cannot provide a score", 0.5, True),  # default
+    ("", 0.5, True),                       # vacio, default
+])
+def test_extract_with_status_reports_default(text, expected_score, expected_default):
+    """El status refleja si el 0.5 viene de regex o de fallback total."""
+    score, was_default = _extract_score_fallback_with_status(text)
+    assert abs(score - expected_score) < 0.001
+    assert was_default is expected_default
+
+
+def test_extract_wrapper_compat():
+    """_extract_score_fallback sigue siendo funcion publica sin cambios."""
+    assert _extract_score_fallback("score: 0.8") == 0.8
+    assert _extract_score_fallback("no score here") == 0.5
+
+
+# -----------------------------------------------------------------------------
+# Tracker via _parse_judge_result (integracion real)
+# -----------------------------------------------------------------------------
+
+
+def test_tracker_empty_when_no_calls():
+    """Sin invocaciones, el snapshot esta vacio."""
+    stats = get_judge_fallback_stats()
+    assert stats == {}
+
+
+def test_tracker_counts_valid_json_as_no_fallback():
+    """Respuesta JSON valida no cuenta como parse_failure ni default."""
+    # Simulamos lo que hace _invoke_judge, pero sin invocar LLM:
+    # llamamos directo a _parse_judge_result con un JSON valido y
+    # registramos la invocacion manualmente (para reflejar el flujo real).
+    from shared.metrics import _judge_fallback_tracker
+    _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+
+    result = _parse_judge_result(
+        '{"score": 0.9, "justification": "OK"}', MetricType.FAITHFULNESS
+    )
+    assert result.value == 0.9
+
+    stats = get_judge_fallback_stats()
+    s = stats["faithfulness"]
+    assert s["invocations"] == 1
+    assert s["parse_failures"] == 0
+    assert s["default_returns"] == 0
+    assert s["parse_failure_rate"] == 0.0
+    assert s["default_return_rate"] == 0.0
+
+
+def test_tracker_counts_parse_failure_but_regex_hit():
+    """JSON invalido + regex extrae score: parse_failure si, default no."""
+    from shared.metrics import _judge_fallback_tracker
+    _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+
+    # Respuesta no parseable como JSON pero con un decimal extraible
+    _parse_judge_result("The score is 0.75 overall.", MetricType.FAITHFULNESS)
+
+    stats = get_judge_fallback_stats()
+    s = stats["faithfulness"]
+    assert s["invocations"] == 1
+    assert s["parse_failures"] == 1
+    assert s["default_returns"] == 0
+
+
+def test_tracker_counts_default_return_as_critical():
+    """JSON invalido + regex falla: parse_failure Y default_return."""
+    from shared.metrics import _judge_fallback_tracker
+    _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+
+    result = _parse_judge_result("I cannot evaluate this.", MetricType.FAITHFULNESS)
+    assert result.value == 0.5
+    assert result.details["fallback_default_used"] is True
+
+    stats = get_judge_fallback_stats()
+    s = stats["faithfulness"]
+    assert s["invocations"] == 1
+    assert s["parse_failures"] == 1
+    assert s["default_returns"] == 1
+    assert s["parse_failure_rate"] == 1.0
+    assert s["default_return_rate"] == 1.0
+
+
+def test_tracker_rates_are_per_metric():
+    """Cada MetricType tiene su propio conjunto de contadores."""
+    from shared.metrics import _judge_fallback_tracker
+
+    # 2 faithfulness: 1 OK, 1 default
+    _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+    _parse_judge_result('{"score": 0.8, "justification": "x"}', MetricType.FAITHFULNESS)
+    _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+    _parse_judge_result("no score", MetricType.FAITHFULNESS)
+
+    # 4 answer_relevance: todas OK
+    for _ in range(4):
+        _judge_fallback_tracker.record_invocation(MetricType.ANSWER_RELEVANCE)
+        _parse_judge_result('{"score": 0.5, "justification": "x"}', MetricType.ANSWER_RELEVANCE)
+
+    stats = get_judge_fallback_stats()
+    assert stats["faithfulness"]["invocations"] == 2
+    assert stats["faithfulness"]["default_returns"] == 1
+    assert stats["faithfulness"]["default_return_rate"] == 0.5
+
+    assert stats["answer_relevance"]["invocations"] == 4
+    assert stats["answer_relevance"]["default_returns"] == 0
+    assert stats["answer_relevance"]["default_return_rate"] == 0.0
+
+
+def test_reset_clears_all_counters():
+    """reset_judge_fallback_stats() limpia todo el estado."""
+    from shared.metrics import _judge_fallback_tracker
+    _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+    _parse_judge_result("garbage", MetricType.FAITHFULNESS)
+
+    assert get_judge_fallback_stats() != {}
+
+    reset_judge_fallback_stats()
+    assert get_judge_fallback_stats() == {}
+
+
+# -----------------------------------------------------------------------------
+# max_judge_default_return_rate
+# -----------------------------------------------------------------------------
+
+
+def test_max_default_return_rate_empty_stats():
+    """Sin stats, retorna (None, 0.0)."""
+    worst, rate = max_judge_default_return_rate({})
+    assert worst is None
+    assert rate == 0.0
+
+
+def test_max_default_return_rate_identifies_worst_metric():
+    """Devuelve la metrica con mayor default_return_rate."""
+    stats = {
+        "faithfulness": {
+            "invocations": 100, "parse_failures": 5, "default_returns": 3,
+            "parse_failure_rate": 0.05, "default_return_rate": 0.03,
+        },
+        "answer_relevance": {
+            "invocations": 100, "parse_failures": 1, "default_returns": 1,
+            "parse_failure_rate": 0.01, "default_return_rate": 0.01,
+        },
+    }
+    worst, rate = max_judge_default_return_rate(stats)
+    assert worst == "faithfulness"
+    assert abs(rate - 0.03) < 1e-9
+
+
+def test_max_default_return_rate_all_zero():
+    """Cuando ninguna metrica tiene fallbacks, retorna (None, 0.0)."""
+    stats = {
+        "faithfulness": {
+            "invocations": 50, "parse_failures": 0, "default_returns": 0,
+            "parse_failure_rate": 0.0, "default_return_rate": 0.0,
+        },
+    }
+    worst, rate = max_judge_default_return_rate(stats)
+    assert worst is None
+    assert rate == 0.0
+
+
+# -----------------------------------------------------------------------------
+# Evaluator threshold validation
+# -----------------------------------------------------------------------------
+
+
+def _make_minimal_config(threshold: float):
+    from sandbox_mteb.config import MTEBConfig, MinIOStorageConfig
+    from shared.config_base import InfraConfig, RerankerConfig
+    from shared.retrieval.core import RetrievalConfig, RetrievalStrategy
+
+    return MTEBConfig(
+        infra=InfraConfig(
+            embedding_base_url="http://fake:8000/v1",
+            embedding_model_name="test-model",
+            llm_base_url="http://fake:8000/v1",
+            llm_model_name="test-llm",
+        ),
+        storage=MinIOStorageConfig(
+            minio_endpoint="http://fake:9000",
+            minio_access_key="x",
+            minio_secret_key="x",
+            minio_bucket="b",
+        ),
+        retrieval=RetrievalConfig(strategy=RetrievalStrategy.SIMPLE_VECTOR),
+        reranker=RerankerConfig(enabled=False),
+        judge_fallback_threshold=threshold,
+    )
+
+
+def test_evaluator_threshold_disabled_never_fails():
+    """threshold=0.0 desactiva la validacion: no lanza aunque haya fallbacks."""
+    from sandbox_mteb.evaluator import MTEBEvaluator
+    from shared.metrics import _judge_fallback_tracker
+
+    ev = MTEBEvaluator(_make_minimal_config(threshold=0.0))
+
+    # Simular 10 invocaciones, todas default_returns (100% fallback)
+    for _ in range(10):
+        _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+        _judge_fallback_tracker.record_parse_failure(MetricType.FAITHFULNESS)
+        _judge_fallback_tracker.record_default_return(MetricType.FAITHFULNESS)
+
+    # No lanza
+    ev._validate_judge_fallback_threshold("test_run")
+
+
+def test_evaluator_threshold_passes_below_limit():
+    """Tasa bajo umbral: no lanza."""
+    from sandbox_mteb.evaluator import MTEBEvaluator
+    from shared.metrics import _judge_fallback_tracker
+
+    ev = MTEBEvaluator(_make_minimal_config(threshold=0.05))
+
+    # 100 invocaciones, 2 default_returns (2% < 5%)
+    for i in range(100):
+        _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+        if i < 2:
+            _judge_fallback_tracker.record_parse_failure(MetricType.FAITHFULNESS)
+            _judge_fallback_tracker.record_default_return(MetricType.FAITHFULNESS)
+
+    ev._validate_judge_fallback_threshold("test_run")  # No lanza
+
+
+def test_evaluator_threshold_raises_above_limit():
+    """Tasa sobre umbral: lanza RuntimeError con mensaje informativo."""
+    from sandbox_mteb.evaluator import MTEBEvaluator
+    from shared.metrics import _judge_fallback_tracker
+
+    ev = MTEBEvaluator(_make_minimal_config(threshold=0.02))
+
+    # 100 invocaciones, 10 default_returns (10% > 2%)
+    for i in range(100):
+        _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+        if i < 10:
+            _judge_fallback_tracker.record_parse_failure(MetricType.FAITHFULNESS)
+            _judge_fallback_tracker.record_default_return(MetricType.FAITHFULNESS)
+
+    with pytest.raises(RuntimeError, match="Tasa de fallback del judge excedida"):
+        ev._validate_judge_fallback_threshold("test_run")
+
+
+def test_evaluator_threshold_uses_worst_metric():
+    """El check se aplica a la metrica peor, no al promedio."""
+    from sandbox_mteb.evaluator import MTEBEvaluator
+    from shared.metrics import _judge_fallback_tracker
+
+    ev = MTEBEvaluator(_make_minimal_config(threshold=0.05))
+
+    # faithfulness: 100 inv, 10 defaults (10%) -> sobre umbral
+    for i in range(100):
+        _judge_fallback_tracker.record_invocation(MetricType.FAITHFULNESS)
+        if i < 10:
+            _judge_fallback_tracker.record_parse_failure(MetricType.FAITHFULNESS)
+            _judge_fallback_tracker.record_default_return(MetricType.FAITHFULNESS)
+
+    # answer_relevance: 100 inv, 0 defaults (0%) -> bajo umbral
+    for _ in range(100):
+        _judge_fallback_tracker.record_invocation(MetricType.ANSWER_RELEVANCE)
+
+    with pytest.raises(RuntimeError, match="faithfulness"):
+        ev._validate_judge_fallback_threshold("test_run")

--- a/tests/test_kg_synthesis.py
+++ b/tests/test_kg_synthesis.py
@@ -1,0 +1,395 @@
+"""
+Tests divergencia LightRAG #2: capa de KG synthesis en generacion.
+
+Verifica:
+  - synthesis se invoca solo con KG data + flag activa
+  - flag desactivada => comportamiento identico (regression guard)
+  - degradacion graceful: error LLM, respuesta vacia, timeout => fallback
+  - truncacion al max_chars cuando el LLM excede budget
+  - faithfulness se evalua contra structured_context, no contra narrativa
+  - tracker contabiliza correctamente y se resetea entre runs
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shared.types import (
+    DatasetType,
+    GenerationResult,
+    MetricType,
+    NormalizedQuery,
+    QueryRetrievalDetail,
+    get_dataset_config,
+)
+from shared.metrics import MetricResult
+
+from sandbox_mteb.generation_executor import (
+    GenerationExecutor,
+    get_kg_synthesis_stats,
+    reset_kg_synthesis_stats,
+)
+
+
+# =============================================================================
+# Fixtures / helpers
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _clean_tracker():
+    reset_kg_synthesis_stats()
+    yield
+    reset_kg_synthesis_stats()
+
+
+def _make_query():
+    return NormalizedQuery(
+        query_id="q1",
+        query_text="who founded the lab?",
+        expected_answer="Alice",
+        answer_type=None,
+    )
+
+
+def _make_retrieval(kg_meta: bool):
+    meta: dict = {}
+    if kg_meta:
+        meta = {
+            "kg_entities": [
+                {"entity": "alice", "description": "founder of the lab"},
+            ],
+            "kg_relations": [
+                {"source": "alice", "target": "lab", "relation": "founded"},
+            ],
+            "lightrag_mode": "hybrid",
+        }
+    return QueryRetrievalDetail(
+        retrieved_doc_ids=["d1"],
+        retrieved_contents=["Alice is the founder of the lab."],
+        retrieval_scores=[0.9],
+        expected_doc_ids=["d1"],
+        retrieval_metadata=meta,
+    )
+
+
+def _make_executor(
+    *,
+    llm_response="answer",
+    synthesis_enabled=True,
+    synthesis_max_chars=0,
+    synthesis_timeout_s=30.0,
+):
+    llm = MagicMock()
+    llm.invoke_async = AsyncMock(return_value=llm_response)
+
+    calc = MagicMock()
+
+    async def _calc_async(mt, **kwargs):
+        return MetricResult(metric_type=mt, value=0.7)
+
+    calc.calculate_async = AsyncMock(side_effect=_calc_async)
+    calc.embedding_model = None
+
+    return GenerationExecutor(
+        llm_service=llm,
+        metrics_calculator=calc,
+        max_context_chars=4000,
+        kg_synthesis_enabled=synthesis_enabled,
+        kg_synthesis_max_chars=synthesis_max_chars,
+        kg_synthesis_timeout_s=synthesis_timeout_s,
+    )
+
+
+# =============================================================================
+# Cuando se invoca / cuando no
+# =============================================================================
+
+
+class TestSynthesisInvocation:
+
+    def test_invoked_when_kg_data_and_flag_on(self):
+        """Con KG data + flag on, el LLM se llama 2 veces (synthesis + gen)."""
+        executor = _make_executor(synthesis_enabled=True)
+        ds_config = get_dataset_config("hotpotqa")
+
+        asyncio.run(
+            executor._process_single_async(
+                _make_query(), _make_retrieval(kg_meta=True),
+                ds_config, "hotpotqa",
+            )
+        )
+
+        # 1 synthesis call + 1 generation call
+        assert executor._llm_service.invoke_async.call_count == 2
+        stats = get_kg_synthesis_stats()
+        assert stats["invocations"] == 1
+        assert stats["successes"] == 1
+
+    def test_skipped_when_no_kg_data(self):
+        """Sin KG data, synthesis no se invoca aunque flag este on."""
+        executor = _make_executor(synthesis_enabled=True)
+        ds_config = get_dataset_config("hotpotqa")
+
+        asyncio.run(
+            executor._process_single_async(
+                _make_query(), _make_retrieval(kg_meta=False),
+                ds_config, "hotpotqa",
+            )
+        )
+
+        # Solo 1 generation call (sin synthesis)
+        assert executor._llm_service.invoke_async.call_count == 1
+        stats = get_kg_synthesis_stats()
+        assert stats["invocations"] == 0
+
+    def test_skipped_when_flag_off(self):
+        """Con KG data pero flag off, synthesis no se invoca (regresion guard)."""
+        executor = _make_executor(synthesis_enabled=False)
+        ds_config = get_dataset_config("hotpotqa")
+
+        asyncio.run(
+            executor._process_single_async(
+                _make_query(), _make_retrieval(kg_meta=True),
+                ds_config, "hotpotqa",
+            )
+        )
+
+        # Solo 1 generation call
+        assert executor._llm_service.invoke_async.call_count == 1
+        stats = get_kg_synthesis_stats()
+        assert stats["invocations"] == 0
+
+
+# =============================================================================
+# Faithfulness contra structured_context original (decision clave)
+# =============================================================================
+
+
+class TestFaithfulnessContext:
+
+    def test_metrics_use_structured_context_not_synthesis(self):
+        """faithfulness/secondary metrics reciben el structured_context, no la narrativa."""
+        executor = _make_executor(
+            synthesis_enabled=True,
+            llm_response="SYNTHESIZED_NARRATIVE",
+        )
+        ds_config = get_dataset_config("hotpotqa")
+
+        with patch(
+            "sandbox_mteb.generation_executor.format_structured_context"
+        ) as mock_struct:
+            mock_struct.return_value = "STRUCTURED_CTX"
+            asyncio.run(
+                executor._process_single_async(
+                    _make_query(), _make_retrieval(kg_meta=True),
+                    ds_config, "hotpotqa",
+                )
+            )
+
+        # Inspeccionar TODOS los kwargs de las llamadas a calculate_async:
+        # ninguna debe haber recibido la narrativa como context.
+        for call in executor._metrics_calculator.calculate_async.call_args_list:
+            ctx = call.kwargs.get("context")
+            if ctx is not None:
+                assert ctx == "STRUCTURED_CTX"
+                assert "SYNTHESIZED_NARRATIVE" not in ctx
+
+    def test_generation_uses_synthesis_narrative(self):
+        """El LLM generador recibe la narrativa, no el structured_context."""
+        executor = _make_executor(
+            synthesis_enabled=True,
+            llm_response="SYNTH_OUT",
+        )
+        ds_config = get_dataset_config("hotpotqa")
+
+        with patch(
+            "sandbox_mteb.generation_executor.format_structured_context"
+        ) as mock_struct:
+            mock_struct.return_value = "STRUCTURED_CTX"
+            asyncio.run(
+                executor._process_single_async(
+                    _make_query(), _make_retrieval(kg_meta=True),
+                    ds_config, "hotpotqa",
+                )
+            )
+
+        # 2 calls: la primera es synthesis (recibe el structured_context),
+        # la segunda es generation (recibe la narrativa SYNTH_OUT en el
+        # user_prompt formateado).
+        calls = executor._llm_service.invoke_async.call_args_list
+        assert len(calls) == 2
+
+        # 2a llamada (generation): el user_prompt debe contener la narrativa
+        gen_user_prompt = calls[1].args[0]
+        assert "SYNTH_OUT" in gen_user_prompt
+
+
+# =============================================================================
+# Degradacion graceful
+# =============================================================================
+
+
+class TestSynthesisFallback:
+
+    def test_llm_error_falls_back_to_structured(self):
+        """Si el LLM lanza, se usa el structured_context original."""
+        # Configuramos llm.invoke_async para fallar la PRIMERA llamada
+        # (synthesis) y devolver respuesta normal en la SEGUNDA (generation).
+        executor = _make_executor(synthesis_enabled=True)
+
+        async def _side_effect(prompt, system_prompt=None, **kw):
+            if "synthesis" in (system_prompt or "").lower() or \
+               "context-synthesis" in (system_prompt or ""):
+                raise RuntimeError("synthesis LLM down")
+            return "generated"
+
+        executor._llm_service.invoke_async = AsyncMock(side_effect=_side_effect)
+
+        ds_config = get_dataset_config("hotpotqa")
+        asyncio.run(
+            executor._process_single_async(
+                _make_query(), _make_retrieval(kg_meta=True),
+                ds_config, "hotpotqa",
+            )
+        )
+
+        stats = get_kg_synthesis_stats()
+        assert stats["invocations"] == 1
+        assert stats["errors"] == 1
+        assert stats["successes"] == 0
+
+    def test_empty_response_falls_back(self):
+        """LLM devuelve solo whitespace => fallback."""
+        executor = _make_executor(synthesis_enabled=True, llm_response="   \n\n  ")
+        ds_config = get_dataset_config("hotpotqa")
+
+        asyncio.run(
+            executor._process_single_async(
+                _make_query(), _make_retrieval(kg_meta=True),
+                ds_config, "hotpotqa",
+            )
+        )
+
+        stats = get_kg_synthesis_stats()
+        assert stats["empty_returns"] == 1
+        assert stats["successes"] == 0
+
+    def test_oversized_response_is_truncated(self):
+        """LLM devuelve > max_chars => truncado, no fallback."""
+        long_response = "A" * 5000
+        executor = _make_executor(
+            synthesis_enabled=True,
+            synthesis_max_chars=100,
+            llm_response=long_response,
+        )
+        ds_config = get_dataset_config("hotpotqa")
+
+        with patch(
+            "sandbox_mteb.generation_executor.format_structured_context"
+        ) as mock_struct:
+            mock_struct.return_value = "STRUCTURED_CTX"
+            asyncio.run(
+                executor._process_single_async(
+                    _make_query(), _make_retrieval(kg_meta=True),
+                    ds_config, "hotpotqa",
+                )
+            )
+
+        stats = get_kg_synthesis_stats()
+        assert stats["truncations"] == 1
+        assert stats["successes"] == 1
+
+        # El generation prompt debe contener la version truncada (100 A),
+        # no la version completa de 5000 A.
+        gen_call = executor._llm_service.invoke_async.call_args_list[1]
+        gen_prompt = gen_call.args[0]
+        assert "A" * 100 in gen_prompt
+        assert "A" * 200 not in gen_prompt
+
+    def test_timeout_falls_back(self):
+        """asyncio.wait_for timeout => contador y fallback."""
+        executor = _make_executor(
+            synthesis_enabled=True,
+            synthesis_timeout_s=0.05,
+        )
+
+        async def _slow_then_fast(prompt, system_prompt=None, **kw):
+            # Si es la llamada de synthesis, dormimos lo suficiente para timeout.
+            if "context-synthesis" in (system_prompt or ""):
+                await asyncio.sleep(1.0)
+                return "never"
+            return "generated"
+
+        executor._llm_service.invoke_async = AsyncMock(side_effect=_slow_then_fast)
+        ds_config = get_dataset_config("hotpotqa")
+        asyncio.run(
+            executor._process_single_async(
+                _make_query(), _make_retrieval(kg_meta=True),
+                ds_config, "hotpotqa",
+            )
+        )
+
+        stats = get_kg_synthesis_stats()
+        assert stats["timeouts"] == 1
+        assert stats["successes"] == 0
+
+
+# =============================================================================
+# Tracker
+# =============================================================================
+
+
+class TestSynthesisTracker:
+
+    def test_tracker_starts_empty(self):
+        stats = get_kg_synthesis_stats()
+        assert stats["invocations"] == 0
+        assert stats["successes"] == 0
+        assert stats["fallback_rate"] == 0.0
+
+    def test_tracker_counts_per_event(self):
+        """Multiple invocaciones se acumulan correctamente."""
+        executor = _make_executor(synthesis_enabled=True)
+        ds_config = get_dataset_config("hotpotqa")
+
+        for _ in range(3):
+            asyncio.run(
+                executor._process_single_async(
+                    _make_query(), _make_retrieval(kg_meta=True),
+                    ds_config, "hotpotqa",
+                )
+            )
+
+        stats = get_kg_synthesis_stats()
+        assert stats["invocations"] == 3
+        assert stats["successes"] == 3
+        assert stats["fallback_rate"] == 0.0
+
+    def test_fallback_rate_computed_correctly(self):
+        """fallback_rate = (errors + empty + timeouts) / invocations."""
+        # Inyectamos eventos directamente al tracker
+        from sandbox_mteb.generation_executor import _kg_synthesis_tracker
+        for _ in range(10):
+            _kg_synthesis_tracker.record("invocations")
+        _kg_synthesis_tracker.record("successes")
+        _kg_synthesis_tracker.record("successes")
+        _kg_synthesis_tracker.record("errors")
+        _kg_synthesis_tracker.record("empty_returns")
+        _kg_synthesis_tracker.record("timeouts")
+
+        stats = get_kg_synthesis_stats()
+        assert stats["invocations"] == 10
+        # 3 fallbacks (1 error + 1 empty + 1 timeout) sobre 10
+        assert abs(stats["fallback_rate"] - 0.3) < 1e-9
+
+    def test_reset_clears_tracker(self):
+        from sandbox_mteb.generation_executor import _kg_synthesis_tracker
+        _kg_synthesis_tracker.record("invocations")
+        _kg_synthesis_tracker.record("successes")
+        assert get_kg_synthesis_stats()["invocations"] == 1
+
+        reset_kg_synthesis_stats()
+        assert get_kg_synthesis_stats()["invocations"] == 0


### PR DESCRIPTION
## Summary

Resolves two P0.5 prerequisites for experiment 3 in one branch:

- **Deuda tecnica #4** — LLM judge fallback rate instrumentation
- **Divergencia LightRAG #2** — LLM synthesis layer for KG context

Plus documentation updates that reflect both changes across `CLAUDE.md`, `README.md`, `TESTS.md` and `env.example`.

### Commits in this PR

| Commit | Summary |
|---|---|
| `2004755` | `feat(metrics): instrument LLM judge fallback rate (tech debt #4)` |
| `789d193` | `feat(lightrag): add LLM synthesis layer for KG context (divergence #2)` |
| `cbce95c` | `docs: update project docs after session-level tech debt resolution` |

### Tech debt #4 — LLM judge fallback instrumentation

Problem: when the LLM judge fails to produce parseable JSON and the regex extractor also fails, `_extract_score_fallback` silently returns `0.5`, biasing metrics (especially `faithfulness`) toward the center. This is the primary signal for hallucination (axis 2 of experiment 3), so the silent bias can produce uninterpretable deltas.

- **`shared/metrics.py`**: `_JudgeFallbackTracker` thread-safe with per-`MetricType` counters (`invocations`, `parse_failures`, `default_returns`) instrumented in `_invoke_judge` / `_invoke_judge_async` / `_parse_judge_result`. Public APIs: `get_judge_fallback_stats()`, `reset_judge_fallback_stats()`, `max_judge_default_return_rate()`. Status-aware extractor variant with back-compat wrapper (DT-9 tests green).
- **`sandbox_mteb/config.py`**: new `JUDGE_FALLBACK_THRESHOLD` env var (default `0.02`). Validated in `MTEBConfig.validate()`.
- **`sandbox_mteb/evaluator.py`**: reset at run start, log stats in `_log_run_complete`, fail run with `RuntimeError` if any metric's `default_return_rate` exceeds threshold.
- **`sandbox_mteb/result_builder.py`**: stats propagated to `config_snapshot._runtime.judge_fallback_stats`.
- **`tests/test_judge_fallback_tracker.py`**: +19 tests (tracker, status-aware extractor, per-metric isolation, threshold disabled/below/above/worst-metric).

### Divergencia LightRAG #2 — KG context synthesis

Problem: after retrieval, LIGHT_RAG presented three sections (entities + relations + chunks) to the generator LLM as separate blocks. The paper calls for an LLM synthesis step that re-writes these as a coherent narrative before generation. F.5 post-refactor showed structured-only sections + proportional budgets are not enough.

- **`sandbox_mteb/generation_executor.py`**: new `_synthesize_kg_context_async()` invoked between `format_structured_context()` and the final LLM call when `has_kg_data` and `kg_synthesis_enabled`. `_KGSynthesisTracker` thread-safe with per-event counters (`invocations`, `successes`, `errors`, `empty_returns`, `truncations`, `timeouts`, `fallback_rate`).
- **Graceful degradation**: any failure (LLM error / empty response / oversized output / timeout) falls back to the structured context. The run never breaks because of synthesis.
- **Integrity decision (B)**: `faithfulness` is evaluated against the **original structured context**, not the synthesized narrative. Any hallucination introduced by the synthesis layer itself is penalized, not masked.
- **`sandbox_mteb/config.py`**: `KG_SYNTHESIS_ENABLED` (default `true`, auto-gated to LIGHT_RAG only), `KG_SYNTHESIS_MAX_CHARS` (default `0` = use `max_context_chars`), `KG_SYNTHESIS_TIMEOUT_S` (default `30.0`). New query-aware prompt `KG_SYNTHESIS_SYSTEM_PROMPT` with anti-fabrication rules, chunk-provenance preservation via `[ref:N]` citations, prefer-chunks-over-KG conflict resolution.
- **`sandbox_mteb/evaluator.py`**: enables synthesis only for LIGHT_RAG; resets tracker at run start; logs stats; emits them in the structured `run_complete` event.
- **`sandbox_mteb/result_builder.py`**: stats propagated to `config_snapshot._runtime.kg_synthesis_stats`.
- **`tests/test_kg_synthesis.py`**: +13 tests (invocation gating, faithfulness-against-structured, graceful fallback in 4 modes, tracker correctness).

### Documentation updates

- **`CLAUDE.md`**: divergence #2 moved to "architectural resolved"; tech debt #4 marked RESOLVED (instrumented); P0.5 reduced to only debt #2 (preflight real); new "Observabilidad de runs" section; `generation_executor` added to bare-excepts table; test coverage updated (382 without igraph verified, ~441 projected with igraph).
- **`README.md`**: strategy table notes reranker auto-off for LIGHT_RAG + synthesis layer; pipeline diagram adds synthesis step; env example block adds the four new vars; development history gets a "Post-refactor (abril 2026)" entry.
- **`TESTS.md`**: rows for `test_judge_fallback_tracker.py` (19) and `test_kg_synthesis.py` (13); DT-9 test count corrected (6 -> 21).
- **`sandbox_mteb/env.example`**: new "LLM JUDGE INSTRUMENTATION" and "KG CONTEXT SYNTHESIS" blocks with rationale.

## Test plan

- [x] `pytest tests/ -m "not integration"` — **382 passed, 7 skipped** (baseline 344 without igraph; +38 net from this session). No regressions.
- [x] `mypy` — no new errors introduced in modified files. Three pre-existing errors unrelated (dotenv/numpy stubs, `retrieval_executor.py:124` union-attr).
- [x] Existing DT-9 extractor tests still green (refactor is API-compatible).
- [x] Existing `test_generation_executor.py::TestStructuredContext` still green (`GenerationExecutor` default `kg_synthesis_enabled=False` preserves legacy behavior).
- [ ] Empirical comparative run post-synthesis (SIMPLE_VECTOR vs LIGHT_RAG with synthesis on/off on HotpotQA) — follow-up, outside this PR.

## Deployment notes

- Defaults are safe: judge threshold `0.02` (2%) is conservative; set `JUDGE_FALLBACK_THRESHOLD=0` to disable.
- `KG_SYNTHESIS_ENABLED=true` only activates for `LIGHT_RAG` runs. For the first empirical run, optionally set `KG_SYNTHESIS_ENABLED=false` to measure the synthesis delta in isolation (ablation).
- Inspect `kg_synthesis_stats.fallback_rate` in output JSON; `>10%` means the run does not reflect the full architecture.

https://claude.ai/code/session_017DswjS7P5HFg3WiEum7Epv