### PR TITLE
docs: blind pipeline validation as structural constraint for claude_code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,11 @@ Patron de fallo observado empiricamente durante el desarrollo: **claude_code tie
 4. Todo parametro que dependa del LLM usado (timeouts, tamaños de contexto, concurrencia) debe ir al `.env`, no a `constants.py`. Si se pone en `constants.py` es porque nunca deberia tocarse (p.ej. `CHARS_PER_TOKEN`).
 5. Cualquier cambio que afecte el contexto que ve el LLM debe tener test que estrese el budget, no solo el caso con budget holgado.
 
+**Validacion a ciegas del pipeline completo**: claude_code no ejecuta en el entorno con NIM+MinIO (ver deuda #9 para el contexto infra; TESTS.md F23 para el e2e actual mockeado). Implicaciones operativas:
+- Cambios que afectan al flujo retrieval→synthesis→generation solo se validan cuando el usuario lanza el run.
+- Antes de declarar un cambio como completo, claude_code debe enumerar los **criterios observables en el run**: que variable de `config_snapshot._runtime` esperar, que valor en `kg_synthesis_stats` o `judge_fallback_stats`, que rango en las metricas agregadas.
+- "Falta test e2e de X" NO es deuda pendiente que claude_code deba resolver — es consecuencia estructural del entorno. Listarla como deuda induce iteraciones futuras intentando construir algo imposible de validar en sesion.
+
 Esta seccion se actualiza con nuevas manifestaciones del patron segun se detecten. No borrar sin consenso.
 
 ## Proximos pasos


### PR DESCRIPTION
## Resumen

Cubre un gap en CLAUDE.md: la consecuencia **operativa** para claude_code de que la infra (NIM+MinIO) solo existe en el entorno local del usuario.

## Contexto

Los hechos ya están documentados distribuidos:
- Deuda #9: lock-in a NIM afecta reproducibilidad (general)
- TESTS.md F23: test e2e actual mockeado (como deuda técnica futura)
- Varias menciones de "requiere NIM + MinIO reales"

Lo que **no** estaba dicho: qué significa esto operativamente para claude_code durante una sesión.

## Cambio

Párrafo nuevo dentro de "Limitaciones de claude_code" que:

1. Reconoce que claude_code trabaja a ciegas sobre el pipeline completo (sin duplicar los hechos infra; referencia deuda #9 y F23).
2. Obliga a enumerar criterios observables en el run antes de declarar cambios como completos.
3. Reclasifica "falta test e2e de X" de deuda pendiente a restricción estructural, previniendo que futuras sesiones gasten iteraciones intentando algo imposible de validar en sesión.

## No destructivo

- Solo añade 5 líneas en CLAUDE.md.
- No modifica deuda #9, F23, ni ninguna otra documentación existente.
- No toca código, tests ni configuración.
- `git revert` deja todo como está hoy.

## Test plan

- [x] Verificación exhaustiva de los 3 .md del repo confirmó que la implicación operativa para claude_code no estaba documentada.
- [x] El párrafo referencia fuentes existentes en vez de restatearlas.
- [ ] N/A — cambio solo de documentación.

https://claude.ai/code/session_01PMsw461DDRpo45G12tDKyi