### PR TITLE
chore(env): fix defaults Pre-P0 + limpieza de comentarios en env.example

### DIFF
--- a/sandbox_mteb/env.example
+++ b/sandbox_mteb/env.example
@@ -1,140 +1,98 @@
 # =========================================================================
 # sandbox_mteb/.env
-# CH_LIRAG - Configuracion completa de un run de evaluacion
+# CH_LIRAG - Configuracion de un run de evaluacion
 # =========================================================================
-# Toda la parametrizacion del run se define aqui.
-# MTEBConfig.from_env() lo lee una sola vez al inicio.
+# MTEBConfig.from_env() lee este fichero una sola vez al inicio del run.
+# Para conceptos (fases P0/P2/P3, divergencias, deudas), ver CLAUDE.md.
+#
+# Convenciones de comentarios:
+#   [INFRA] — especifico de la infra; reemplazar por la tuya.
+#   [DEFAULT] — valor por defecto recomendado (cambiar solo con razon).
+#   [PRE-P0 VALIDATED] — valor probado en el run mteb_hotpotqa_20260419_032905
+#       sobre nvidia/nemotron-3-nano; cambiar invalida la referencia.
 
 # =========================================================================
 # EMBEDDING (NIM)
 # =========================================================================
-#EMBEDDING_MODEL_NAME=nvidia/llama-3.2-nv-embedqa-1b-v2
-#EMBEDDING_BASE_URL=http://172.30.79.98:8000/v1
-#EMBEDDING_MODEL_TYPE=asymmetric
-
+# [INFRA]
 EMBEDDING_MODEL_NAME=llama-embed-nemotron-8b
 EMBEDDING_BASE_URL=http://172.30.79.103:8000/v1
 EMBEDDING_MODEL_TYPE=asymmetric
 
-# Batch size para indexacion de embeddings. Default=50.
-# Reducir si el NIM de embeddings tiene poca memoria.
+# [DEFAULT] Batch de indexacion. Reducir si el NIM tiene poca memoria.
 EMBEDDING_BATCH_SIZE=5
 
 # =========================================================================
 # LLM (NIM) - generacion + LLM-judge
 # =========================================================================
+# [INFRA]
 LLM_BASE_URL=http://172.30.79.99:8000/v1
 LLM_MODEL_NAME=nvidia/nemotron-3-nano
 
-# Concurrencia y reintentos contra NIM.
-# ATENCION: las variables son NIM_MAX_CONCURRENT_REQUESTS y NIM_REQUEST_TIMEOUT
-# (no NIM_MAX_CONCURRENT ni NIM_TIMEOUT).
-NIM_MAX_CONCURRENT_REQUESTS=32
-NIM_REQUEST_TIMEOUT=120
-NIM_MAX_RETRIES=3
+# ATENCION: los nombres exactos son NIM_MAX_CONCURRENT_REQUESTS y
+# NIM_REQUEST_TIMEOUT (no NIM_MAX_CONCURRENT ni NIM_TIMEOUT).
+NIM_MAX_CONCURRENT_REQUESTS=32  # [PRE-P0 VALIDATED]
+NIM_REQUEST_TIMEOUT=120         # [DEFAULT]
+NIM_MAX_RETRIES=3               # [DEFAULT]
 
 # =========================================================================
 # RETRIEVAL
 # =========================================================================
 # Estrategias validas: SIMPLE_VECTOR, LIGHT_RAG
-RETRIEVAL_STRATEGY=SIMPLE_VECTOR
+RETRIEVAL_STRATEGY=SIMPLE_VECTOR  # [DEFAULT]
+RETRIEVAL_K=20                    # [DEFAULT]
 
-# Docs recuperados para calcular metricas de retrieval (pre-rerank).
-RETRIEVAL_K=20
-
-# Threads para construccion del grafo HNSW (ChromaDB). 1 = determinista
-# (reproducible entre runs). Valores > 1 aceleran indexacion pero el
-# no-determinismo de threading produce resultados ligeramente diferentes.
-# ChromaDB 0.5-0.6 no soporta hnsw:random_seed.
+# [DEFAULT] Threads del grafo HNSW (ChromaDB). 1 = determinista entre runs.
+# ChromaDB 0.5-0.6 no expone hnsw:random_seed (ver CLAUDE.md deuda #3).
 HNSW_NUM_THREADS=1
 
 # =========================================================================
 # RERANKER (cross-encoder, opcional)
 # =========================================================================
-RERANKER_ENABLED=true
-RERANKER_BASE_URL=http://172.30.79.98:9000/v1
-RERANKER_MODEL_NAME=nvidia/llama-3.2-nv-rerankqa-1b-v2
-# Docs pasados al LLM para generacion tras reranking.
-RERANKER_TOP_N=5
-# Candidatos a recuperar para el reranker. 0 = top_n * 3 (default).
+RERANKER_ENABLED=true                                       # [DEFAULT]
+RERANKER_BASE_URL=http://172.30.79.98:9000/v1               # [INFRA]
+RERANKER_MODEL_NAME=nvidia/llama-3.2-nv-rerankqa-1b-v2      # [INFRA]
+RERANKER_TOP_N=5                                            # [DEFAULT]
+# [DEFAULT] 0 = top_n * 3
 RERANKER_FETCH_K=0
 
 # =========================================================================
 # DATASET Y EVALUACION
 # =========================================================================
-MTEB_DATASET_NAME=hotpotqa
+MTEB_DATASET_NAME=hotpotqa  # [DEFAULT]
 
-# 0 = usar todas las queries / todo el corpus.
-# Defaults en codigo: 50 / 1000 si no se especifica.
+# [DEFAULT] 0 = usar todas las queries / todo el corpus.
 EVAL_MAX_QUERIES=50
 EVAL_MAX_CORPUS=1000
 
-GENERATION_ENABLED=true
+GENERATION_ENABLED=true  # [DEFAULT]
 
-# Limite de caracteres para contexto de generacion.
-# 0 = auto-derivar del context window del modelo via GET /v1/models.
-#     Formula: (max_model_len - 1024 overhead) * 4.0 chars/token.
-# >0 = override manual en caracteres.
+# [DEFAULT] Limite de caracteres para contexto de generacion.
+# 0 = auto-derivar del modelo via GET /v1/models.
+# Fallback silencioso a 4000 si la deteccion falla (ver CLAUDE.md deuda #5).
 GENERATION_MAX_CONTEXT_CHARS=0
 
-# =========================================================================
-# LLM JUDGE INSTRUMENTATION (deuda tecnica #4)
-# =========================================================================
-# El LLM judge de faithfulness/answer_relevance puede fallar a producir
-# JSON parseable; en ese caso se intenta extraer el score via regex y,
-# si tambien falla, se devuelve 0.5 por defecto (sesga metricas hacia
-# el centro). El run se marca como fallido si la tasa de "default_returns"
-# supera este umbral para cualquier metrica del judge.
-# 0.0 desactiva la validacion (no fallar nunca).
-# Default 0.02 (2%) — razonable para judges modernos bien prompteados.
+# [DEFAULT] LLM judge: si default_return_rate supera este umbral en
+# cualquier metrica invocada, el run falla. 0.0 desactiva la validacion.
 JUDGE_FALLBACK_THRESHOLD=0.02
 
-# =========================================================================
-# JERARQUIA DE LIMITES DE TOKENS/CARACTERES
-# =========================================================================
-# El pipeline aplica 3 limites en distintas fases. De mayor a menor:
-#
-# 1. max_tokens = 4096 (shared/llm.py)
-#    Parametro enviado al LLM NIM indicando cuantos tokens COMO MAXIMO
-#    puede generar en su respuesta. Es un techo de la API OpenAI-compatible.
-#    En la practica el LLM para cuando termina (50-200 tokens en HotpotQA).
-#    Default estandar de NIM/OpenAI. No configurable via .env (API interna).
-#
-# 2. GENERATION_MAX_CONTEXT_CHARS / 4000 fallback (sandbox_mteb/evaluator.py)
-#    Cuantos caracteres de CONTEXTO (documentos recuperados) se envian al LLM
-#    para que genere su respuesta. Prioridad:
-#      a) GENERATION_MAX_CONTEXT_CHARS > 0 en .env -> usa ese valor directo
-#      b) Auto-deteccion via GET /v1/models -> (max_model_len - 1024) * 4.0
-#      c) Fallback = 4000 chars (~1000 tokens) si a) y b) fallan
-#    El fallback 4000 es conservador a proposito: seguro para cualquier modelo.
-#
-# 3. _MAX_RESPONSE_CHARS_FOR_JUDGE = 2000 (shared/metrics.py)
-#    Cuantos caracteres de la RESPUESTA GENERADA se envian al LLM Judge
-#    para evaluarla (faithfulness, relevance, context_utilization).
-#    Guarda defensiva contra respuestas degeneradas (repeticiones infinitas).
-#    2000 chars (~500 tokens) es holgado para cualquier respuesta razonable.
-#    No configurable via .env (constante interna en shared/metrics.py).
-
-# Seed para shuffle del corpus antes de slice.
-# Evita sesgo de orden (corpus alineado con queries en Parquet).
-# -1 = desactivar shuffle (NO recomendado).
+# [DEFAULT] Seed para shuffle del corpus antes de slice. -1 = sin shuffle.
 CORPUS_SHUFFLE_SEED=42
 
 # =========================================================================
 # MODO DESARROLLO
 # =========================================================================
-# Subset inteligente: selecciona N queries y garantiza sus gold docs
-# en el corpus, rellenando con distractores aleatorios.
-# Ignora EVAL_MAX_QUERIES y EVAL_MAX_CORPUS cuando esta activo.
-# Metricas NO comparables con runs completos (ratio gold/distractores elevado).
-DEV_MODE=true
-# Defaults en codigo: 200 / 4000 si no se especifica.
-DEV_QUERIES=200
-DEV_CORPUS_SIZE=4000
+# Selecciona N queries y garantiza sus gold docs en el corpus con
+# distractores aleatorios. Ignora EVAL_MAX_QUERIES/EVAL_MAX_CORPUS.
+# Metricas NO comparables con runs completos.
+DEV_MODE=true          # [DEFAULT]
+DEV_QUERIES=200        # [DEFAULT]
+DEV_CORPUS_SIZE=4000   # [DEFAULT]
 
 # =========================================================================
 # MINIO (S3-compatible)
 # =========================================================================
+# [INFRA]
 MINIO_ENDPOINT=http://172.30.79.110:9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minio123
@@ -144,125 +102,85 @@ S3_DATASETS_PREFIX=datasets/evaluation
 # =========================================================================
 # KNOWLEDGE GRAPH (solo LIGHT_RAG)
 # =========================================================================
-# Requiere: pip install python-igraph snowballstemmer
-# Sin igraph o sin LLM service, LIGHT_RAG degrada a SimpleVector puro.
+# Requiere python-igraph. Sin igraph o sin LLM, LIGHT_RAG degrada
+# a SimpleVector puro.
 
-# Modo de retrieval LightRAG (paper original):
-#   hybrid — entidades + relaciones + vector chunks (default)
-#   local  — entidades + vector chunks
-#   global — relaciones + vector chunks
-#   naive  — solo vector search, sin KG (= SIMPLE_VECTOR)
-# Todos los modos (excepto naive) presentan secciones separadas al LLM.
+# [DEFAULT] Modos: hybrid (ent + rel + chunks), local (ent + chunks),
+#                  global (rel + chunks), naive (= SIMPLE_VECTOR)
 LIGHTRAG_MODE=hybrid
 
-# Chunks enviados al LLM para generacion tras KG-scoring.
-# Paper original: CHUNK_TOP_K=20 (con GPT-4o-mini).
-# El KG rankea chunks por reference-count scoring; este parametro selecciona
-# los top-N para el generador, analogo a RERANKER_TOP_N en SIMPLE_VECTOR.
-# Metricas de retrieval (Hit@K, MRR, Recall@K) se calculan sobre RETRIEVAL_K
-# completo; generacion usa solo los top-N mejor rankeados por el KG.
-# 0 = usar RETRIEVAL_K (todos los docs van a generacion, sin separacion).
-# Reducir para LLMs mas lentos que GPT-4o-mini.
+# [DEFAULT] Top-N de chunks al LLM para generacion (post KG-scoring).
+# 0 = usar RETRIEVAL_K (sin separacion retrieval/generacion).
 LIGHTRAG_GENERATION_TOP_N=10
 
-# Profundidad maxima de BFS en graph traversal durante retrieval.
-# DAM-7: default cambiado de 2 a 1 (como el original).
+# [DEFAULT] Profundidad BFS en graph traversal (paper original: 1).
 KG_MAX_HOPS=1
 
-# Max caracteres de documento enviados al LLM para extraccion de tripletas.
+# [DEFAULT] Caracteres de documento al LLM para extraccion de tripletas.
 KG_MAX_TEXT_CHARS=3000
 
-# Vecinos 1-hop por entidad resuelta en retrieval (divergencia #9).
-# Cada entidad recuperada via Entity VDB incluye sus N vecinos mas relevantes
-# del grafo, rankeados por edge_weight + degree_centrality.
-# 0 = desactivado (sin expansion de vecinos).
+# [DEFAULT] Vecinos 1-hop por entidad resuelta (divergencia #9).
+# Rankeados por edge_weight + degree_centrality. 0 = desactivado.
 KG_MAX_NEIGHBORS_PER_ENTITY=5
 
-# Cap de entidades en el Knowledge Graph. 0 = default (100000).
-# DTm-63: al alcanzar el cap, entidades de baja importancia (1 doc, degree<=1)
-# se evictan para dar paso a nuevas. Si no hay candidato evictable, se descarta.
+# [DEFAULT] Cap de entidades en el KG. 0 = 100000 (hardcoded).
+# Al saturarse se evictan entidades de baja importancia (1 doc, degree<=1).
 KG_MAX_ENTITIES=0
 
-# Max tokens para LLM call de keyword extraction (query analysis).
-# Default=1024. Subir a 2048 si el modelo usa thinking-mode y agota tokens
-# en razonamiento antes de generar la respuesta JSON.
+# [DEFAULT] Max tokens de la llamada LLM de keyword extraction.
+# Subir si el modelo es thinking-mode y agota tokens en razonamiento.
 KG_KEYWORD_MAX_TOKENS=1024
 
-# Max tokens para LLM call de extraccion de tripletas (DTm-66).
-# Default=4096 (antes 8192). Con thinking-mode, el modelo genera miles
-# de tokens de <think> que luego se descartan. Reducir acota esa generacion.
-# Para batch multi-doc, el cap es 2x este valor (e.g. 8192 para 5 docs).
+# [DEFAULT] Max tokens para extraccion de tripletas. Batch multi-doc usa 2x.
 KG_EXTRACTION_MAX_TOKENS=4096
 
-# Docs por LLM call en batch extraction de tripletas (DTm-67).
-# Default=5 (reducido desde 10). Cada doc aporta ~750 tokens (3000 chars / 4).
-# Con thinking-mode models (e.g. nemotron-3-nano), batches grandes causan
-# thinking exhaustion: el modelo gasta todos los output tokens en <think>
-# tags sin producir JSON. Bajar si hay muchos "Batch parse failed" warnings.
-# Subir (max ~10) solo si el modelo no es thinking-mode o tiene context amplio.
+# [DEFAULT] Docs por llamada LLM en batch extraction. Subir solo si el
+# modelo no es thinking-mode; con nemotron-3-nano, batches grandes causan
+# exhaustion (<think> agota tokens antes del JSON).
 KG_BATCH_DOCS_PER_CALL=5
 
-# Directorio para persistir el Knowledge Graph entre runs.
-# Si configurado, el KG se cachea como JSON y se reutiliza si el corpus
-# no cambia (validado por fingerprint). Vacio = sin cache (reconstruir siempre).
+# [DEFAULT] Cachear el KG entre runs (validado por fingerprint del corpus).
+# Vacio = reconstruir siempre.
 KG_CACHE_DIR=
 
-# LLM synthesis para descripciones de entidades multi-doc (DAM-4/A5.1).
-# Cuando activado, entidades cuya descripcion concatenada excede el threshold
-# se sintetizan via LLM en una descripcion coherente (como en el paper original).
-# Incrementa calidad del KG pero consume LLM calls adicionales.
+# [DEFAULT] LLM synthesis para descripciones de entidades multi-doc.
+# Consume llamadas extra al LLM durante indexacion.
 KG_DESCRIPTION_SYNTHESIS=false
 KG_SYNTHESIS_CHAR_THRESHOLD=200
 
-# Chunk high-level keywords (divergencia #10, solo LIGHT_RAG).
-# Durante indexacion el LLM extrae keywords tematicas por chunk (piggyback
-# en la llamada de triplet extraction). Estas keywords se indexan en una
-# VDB dedicada (Chunk Keywords VDB) y se usan en el path high-level de
-# retrieval para conectar queries con chunks por tematica, no solo via
-# relaciones. Temas como "metodologia", "limitaciones", etc. que no se
-# expresan como relaciones entre entidades se capturan por este canal.
-# Desactivar solo para auditar la contribucion del canal vs sin el.
+# [DEFAULT] Chunk high-level keywords VDB (divergencia #10).
+# Indexa keywords tematicas por chunk (piggyback en triplet extraction)
+# para conectar queries con chunks por tema, no solo via relaciones.
 KG_CHUNK_KEYWORDS_ENABLED=true
-
-# Top-K devueltos por cada high-level keyword de la query al consultar
-# la Chunk Keywords VDB. Cada chunk matched contribuye al doc_scores con
-# la formula simetrica `1/(1+rank) * similarity`. 20 alineado con RETRIEVAL_K.
+# [DEFAULT] Top-K al consultar la Chunk Keywords VDB por cada keyword.
 KG_CHUNK_KEYWORDS_TOP_K=20
 
 # =========================================================================
 # KG CONTEXT SYNTHESIS (divergencia LightRAG #2, solo LIGHT_RAG)
 # =========================================================================
-# Cuando hay datos KG en el retrieval (entidades/relaciones), el contexto
-# multi-seccion (entidades + relaciones + chunks) se reescribe como
-# narrativa coherente via LLM ANTES de la generacion final. El prompt es
-# query-aware y preserva citas [ref:N] a los chunks originales.
-# Faithfulness se sigue evaluando contra el contexto estructurado original,
-# NO contra la narrativa, para penalizar cualquier alucinacion introducida
-# por la propia synthesis.
-# Degradacion graceful: error LLM / vacio / timeout / oversize -> fallback
-# al contexto estructurado. Stats en config_snapshot._runtime.kg_synthesis_stats.
-KG_SYNTHESIS_ENABLED=true
+# Reescribe el contexto KG como narrativa coherente via LLM antes de
+# la generacion final. Preserva citas [ref:N] a los chunks originales.
+# Faithfulness se evalua contra el contexto estructurado, NO contra
+# la narrativa, para penalizar alucinacion de la propia synthesis.
+# Fallback al contexto estructurado ante error/vacio/timeout.
+KG_SYNTHESIS_ENABLED=true  # [DEFAULT]
 
-# Limite de output de la synthesis en caracteres.
-# 0 = usar el mismo limite que la generacion (max_context_chars del run).
-# Pre-P0 validado (run `mteb_hotpotqa_20260419_032905` sobre nvidia/nemotron-3-nano):
-# 50000 cerro fallback_rate al 2.86% sin regresion en avg_gen_score.
-# Si cambias de LLM y observas fallback_rate > 10%, empieza por bajar este valor
-# antes de subir el timeout (ver CLAUDE.md deuda #16 para el diagnostico).
-KG_SYNTHESIS_MAX_CHARS=0
+# [PRE-P0 VALIDATED] Limite de output de la synthesis en caracteres.
+# 0 = usar el mismo limite que la generacion. 50000 cerro fallback_rate
+# al 2.86% en el run 032905 (ver CLAUDE.md deuda #16).
+KG_SYNTHESIS_MAX_CHARS=50000
 
-# Timeout dedicado para la llamada de synthesis (1 LLM call extra por query).
-# Si se supera, fallback al contexto estructurado.
-# Pre-P0 validado (run `mteb_hotpotqa_20260419_032905` sobre nvidia/nemotron-3-nano
-# con NIM_MAX_CONCURRENT_REQUESTS=32 y 35 queries): 180s fue necesario porque
-# p95_llm_ms ~114s + queue p95 ~39s se come 90s en el tail. Si tu NIM es mas
-# rapido o corres menos queries concurrentes, 90s puede bastar. Verifica
-# post-run con `jq '.config_snapshot._runtime.kg_synthesis_stats.fallback_rate'`.
-KG_SYNTHESIS_TIMEOUT_S=90.0
+# [PRE-P0 VALIDATED] Timeout de la llamada de synthesis. Si se supera,
+# fallback al contexto estructurado. 180s cubre el p95_llm (~114s) +
+# queue p95 (~39s) con NIM_MAX_CONCURRENT_REQUESTS=32. Verificar
+# post-run con:
+#   jq '.config_snapshot._runtime.kg_synthesis_stats.fallback_rate'
+KG_SYNTHESIS_TIMEOUT_S=180
 
 # =========================================================================
 # PATHS (relativos al directorio de ejecucion)
 # =========================================================================
+# [DEFAULT]
 DATASETS_CACHE_DIR=./data/datasets_cache
 EVALUATION_RESULTS_DIR=./data/results
 VECTOR_DB_DIR=./data/vector_db


### PR DESCRIPTION
## Contexto

Al auditar tras el merge de PR #45, el usuario detecto que su `.env` local (tras copiar desde `env.example`) tenia `KG_SYNTHESIS_TIMEOUT_S=90.0` — valor que no coincide con lo validado en el run Pre-P0 `mteb_hotpotqa_20260419_032905` (180s).

Investigacion (ver historial de env.example via `git log -G`): el commit `fa97042` ("Pre-P0 cerrado") actualizo los comentarios del fichero para documentar la config validada (`KG_SYNTHESIS_MAX_CHARS=50000`, `KG_SYNTHESIS_TIMEOUT_S=180`) pero dejo los defaults anclados a valores anteriores (`0`, `90.0`). Contradiccion interna: el comentario dice "180s fue necesario" pero el valor es `90.0`.

Cualquier usuario copiando `env.example` -> `.env` heredaba una config que no reproducia el comportamiento del run de referencia.

## Cambios

### Defaults corregidos al valor validado Pre-P0

| Variable | Antes | Ahora |
|---|---|---|
| `KG_SYNTHESIS_MAX_CHARS` | `0` | `50000` |
| `KG_SYNTHESIS_TIMEOUT_S` | `90.0` | `180` |

`NIM_MAX_CONCURRENT_REQUESTS=32` ya coincidia.

### Refactor de comentarios

Usuario pidio eliminar comentarios que no aportan al uso actual. Cambios:

- **Eliminado**: bloque tutorial "JERARQUIA DE LIMITES DE TOKENS/CARACTERES" (duplicaba contenido de CLAUDE.md).
- **Eliminado**: referencias a deudas internas de desarrollo (DTm-63, DTm-66, DTm-67, DAM-4/6/7, A5.1) que no ayudan a configurar.
- **Eliminada** narrativa historica ("Default=5 (reducido desde 10)", "Default=4096 (antes 8192)").
- **Eliminadas** lineas comentadas de infra antigua (embedding nvidia/llama-3.2-nv-embedqa-1b-v2 vs llama-embed-nemotron-8b).
- **Eliminado** comentario trivial auto-explicativo por el nombre de la variable.

### Marcadores de clasificacion

Cada variable lleva una etiqueta consistente en su comentario o inline:

- `[INFRA]` — especifico de la infra local; reemplazar.
- `[DEFAULT]` — default recomendado; cambiar solo con razon.
- `[PRE-P0 VALIDATED]` — valor probado en el run `032905`; cambiar invalida la referencia de Pre-P0. Aplica a `NIM_MAX_CONCURRENT_REQUESTS=32`, `KG_SYNTHESIS_MAX_CHARS=50000`, `KG_SYNTHESIS_TIMEOUT_S=180`.

## Impacto

- **Tamano**: 269 -> 186 lineas (-31%).
- **Bloques comentario**: ~16 -> ~8.
- **Suite de tests**: 494 passed, 7 skipped (sin regresiones; `env.example` no es codigo).
- **Runs nuevos**: un usuario copiando `env.example` -> `.env` ahora reproduce la config Pre-P0 sin edicion manual.

## Tocar `env.example` no altera la runtime

`env.example` es un template. Los `.env` locales existentes no se ven afectados (estan en `.gitignore`). Solo afecta a usuarios que copien desde cero.
