### PR TITLE
fix(env): restaurar toggle de embedding alternativo borrado en PR #46

### DIFF
--- a/sandbox_mteb/env.example
+++ b/sandbox_mteb/env.example
@@ -14,7 +14,12 @@
 # =========================================================================
 # EMBEDDING (NIM)
 # =========================================================================
-# [INFRA]
+# [INFRA] Descomentar el bloque activo y comentar el otro para alternar
+# entre modelos de embedding disponibles en la infra.
+#EMBEDDING_MODEL_NAME=nvidia/llama-3.2-nv-embedqa-1b-v2
+#EMBEDDING_BASE_URL=http://172.30.79.98:8000/v1
+#EMBEDDING_MODEL_TYPE=asymmetric
+
 EMBEDDING_MODEL_NAME=llama-embed-nemotron-8b
 EMBEDDING_BASE_URL=http://172.30.79.103:8000/v1
 EMBEDDING_MODEL_TYPE=asymmetric


### PR DESCRIPTION
## Contexto

El commit `439ea8e` del PR #46 elimino por error 3 lineas comentadas que eran un **toggle de infra operativo** (bloque alternativo de embedding), no narrativa historica:

```
#EMBEDDING_MODEL_NAME=nvidia/llama-3.2-nv-embedqa-1b-v2
#EMBEDDING_BASE_URL=http://172.30.79.98:8000/v1
#EMBEDDING_MODEL_TYPE=asymmetric
```

El usuario las tenia comentadas como patron deliberado para alternar entre dos modelos de embedding disponibles en su infra local. Mi criterio de corte en el refactor las agrupo con otras lineas comentadas que eran narrativa historica y se perdieron en la limpieza.

## Cambio

Restaura las 3 lineas + 2 de comentario nuevo explicando que es un patron [INFRA] de toggle, para que futuras limpiezas no las borren de nuevo pensando que son residuo.

Diff total: 6 lineas anadidas, 1 eliminada (la etiqueta [INFRA] solitaria pasa a llevar explicacion).

## Lo que SE CONSERVA del PR #46

- Defaults Pre-P0 validados (`KG_SYNTHESIS_MAX_CHARS=50000`, `KG_SYNTHESIS_TIMEOUT_S=180`)
- Marcadores `[INFRA]` / `[DEFAULT]` / `[PRE-P0 VALIDATED]`
- Eliminacion del bloque tutorial `JERARQUIA DE LIMITES` (duplicado en CLAUDE.md)
- Eliminacion de referencias a deudas internas de desarrollo (DTm-*, DAM-*)
- Eliminacion de narrativa historica ("antes 8192", "reducido desde 10")

## Suite

494 passed, 7 skipped (sin regresiones — `env.example` no es codigo).
