### PR TITLE
chore(env): exponer KG_GLEANING_ROUNDS en env.example

### DIFF
--- a/sandbox_mteb/env.example
+++ b/sandbox_mteb/env.example
@@ -144,6 +144,15 @@ KG_EXTRACTION_MAX_TOKENS=4096
 # exhaustion (<think> agota tokens antes del JSON).
 KG_BATCH_DOCS_PER_CALL=5
 
+# [DEFAULT] Rondas de re-extraccion para capturar entidades perdidas.
+# 0 = desactivado (default Pre-P0). 1 = una pasada extra tras la inicial;
+# el prompt de gleaning lista las entidades ya extraidas y pide al LLM
+# que busque las que faltan. Recomendado si hay muchos warnings
+# "Batch parse failed" o "empty content" durante la extraccion inicial
+# — recupera la senal que el thinking-mode o la saturacion de tokens
+# dejo escapar. Coste: ~2x llamadas LLM durante indexacion.
+KG_GLEANING_ROUNDS=0
+
 # [DEFAULT] Cachear el KG entre runs (validado por fingerprint del corpus).
 # Vacio = reconstruir siempre.
 KG_CACHE_DIR=


### PR DESCRIPTION
## Contexto

Durante la auditoria del run `mteb_hotpotqa_20260419_181645` detectamos muchos warnings de `Batch parse failed` y `empty content` durante la extraccion inicial de tripletas (thinking-mode exhaustion del NIM `nemotron-3-nano`). Para recuperar la senal perdida recomende al usuario activar `KG_GLEANING_ROUNDS=1`, pero el parametro **no estaba en `env.example`** — el usuario tuvo que preguntar.

Verificacion:
```
git log --all -G"KG_GLEANING_ROUNDS" -- sandbox_mteb/env.example
(0 commits — nunca estuvo en el template)
```

Gap preexistente del repo, **no introducido por PR #46** (refactor previo).

## Cambio

Anade 9 lineas al `env.example` exponiendo `KG_GLEANING_ROUNDS=0` con marcador `[DEFAULT]`, agrupado con los otros parametros de extraccion de tripletas (`KG_BATCH_DOCS_PER_CALL`, `KG_EXTRACTION_MAX_TOKENS`).

El valor `0` mantiene la config Pre-P0 validada (el run `032905` corrio con gleaning desactivado).

## Contexto para el usuario (incluido en el comentario)

Cuando subir a `1`:
- Muchos warnings `Batch parse failed` durante extraccion inicial
- Thinking-mode o saturacion de tokens dejo perder entidades en la pasada inicial
- Coste: ~2x llamadas LLM durante indexacion

Cuando dejar en `0`:
- Runs de validacion contra baseline Pre-P0 (misma config que `032905`)
- Presupuesto NIM ajustado
- Extraccion inicial ya saturada en cobertura (>95% docs_with_entities)

## Impacto

- `env.example`: +9 lineas.
- Codigo: no tocado (`shared/retrieval/core.py:96` ya leia este env var desde hace varias sesiones con default=0).
- Tests: no hace falta — el parametro ya estaba cubierto por tests preexistentes del gleaning.
- Runs existentes: no afectados (defaults de codigo estaban ya en 0).
