### PR TITLE
Fase 1: cerrar dt-11 y dt-14 (-7 lineas netas)

### DIFF
--- a/shared/retrieval/core.py
+++ b/shared/retrieval/core.py
@@ -180,6 +180,18 @@ class SimpleVectorRetriever(BaseRetriever):
         self.embedding_batch_size = embedding_batch_size
         self._vector_store: Any = None  # ChromaVectorStore, lazy import
 
+    @property
+    def active_collection_name(self) -> Optional[str]:
+        """Nombre real de la coleccion ChromaDB activa, o None si no indexado.
+
+        Consumidores externos (p.ej. LightRAGRetriever construyendo VDBs
+        auxiliares) deben usar esta property en vez de acceder a
+        `_vector_store.collection_name` directamente.
+        """
+        if self._vector_store is not None:
+            return self._vector_store.collection_name
+        return self.collection_name
+
     def _init_vector_store(self, collection_name: str) -> None:
         from shared.vector_store import ChromaStoreConfig, ChromaVectorStore
 

--- a/shared/retrieval/lightrag/knowledge_graph.py
+++ b/shared/retrieval/lightrag/knowledge_graph.py
@@ -282,30 +282,6 @@ class KnowledgeGraph:
         neighbor_vids = self._graph.neighbors(vid)
         return [self._graph.vs[nv]["name"] for nv in neighbor_vids]
 
-    def _get_neighbors_weighted(self, name: str) -> List[Tuple[str, float]]:
-        """Return neighbors with edge weight factor.
-
-        Weight = log(1 + unique_docs_on_edge). Co-occurrence edges (1 doc)
-        get ~0.69, strong LLM edges (10 docs) get ~2.40.
-
-        Returns:
-            List of (neighbor_name, weight_factor) tuples.
-        """
-        vid = self._name_to_vid.get(name)
-        if vid is None:
-            return []
-        result: List[Tuple[str, float]] = []
-        for eid in self._graph.incident(vid):
-            edge = self._graph.es[eid]
-            neighbor_vid = edge.target if edge.source == vid else edge.source
-            neighbor_name = self._graph.vs[neighbor_vid]["name"]
-            # Edge weight = unique docs mentioning this edge
-            relations = edge["relations"]
-            unique_docs = len({r.get("doc_id", "") for r in relations if r.get("doc_id")})
-            weight_factor = math.log1p(max(unique_docs, 1))
-            result.append((neighbor_name, weight_factor))
-        return result
-
     def get_neighbors_ranked(
         self, name: str, max_neighbors: int = 5,
     ) -> List[Dict[str, Any]]:

--- a/shared/retrieval/lightrag/retriever.py
+++ b/shared/retrieval/lightrag/retriever.py
@@ -150,6 +150,18 @@ class LightRAGRetriever(BaseRetriever):
         self._query_keywords_cache: OrderedDict[str, Tuple[List[str], List[str]]] = OrderedDict()
         self._cache_lock = threading.Lock()
 
+    def _aux_vdb_collection_name(self, suffix: str) -> str:
+        """Deriva el nombre de una VDB auxiliar (entities/relationships/chunk_keywords)
+        del nombre activo del ChromaVectorStore principal.
+        """
+        base = self._vector_retriever.active_collection_name
+        if not base:
+            raise RuntimeError(
+                "No se puede derivar nombre de VDB auxiliar: vector store "
+                "principal no tiene coleccion activa"
+            )
+        return f"{base}_{suffix}"
+
     def index_documents(
         self,
         documents: List[Dict[str, Any]],
@@ -426,9 +438,7 @@ class LightRAGRetriever(BaseRetriever):
         from shared.vector_store import ChromaVectorStore
         from langchain_core.documents import Document
 
-        # Collection name: {base}_entities para no colisionar con docs
-        base_name = self._vector_retriever._vector_store.collection_name
-        entity_collection_name = f"{base_name}_entities"
+        entity_collection_name = self._aux_vdb_collection_name("entities")
 
         # Limpiar VDB anterior si existe
         if self._entities_vdb is not None:
@@ -532,8 +542,7 @@ class LightRAGRetriever(BaseRetriever):
         from shared.vector_store import ChromaVectorStore
         from langchain_core.documents import Document
 
-        base_name = self._vector_retriever._vector_store.collection_name
-        rel_collection_name = f"{base_name}_relationships"
+        rel_collection_name = self._aux_vdb_collection_name("relationships")
 
         if self._relationships_vdb is not None:
             try:
@@ -625,8 +634,7 @@ class LightRAGRetriever(BaseRetriever):
         from shared.vector_store import ChromaVectorStore
         from langchain_core.documents import Document
 
-        base_name = self._vector_retriever._vector_store.collection_name
-        ck_collection_name = f"{base_name}_chunk_keywords"
+        ck_collection_name = self._aux_vdb_collection_name("chunk_keywords")
 
         if self._chunk_keywords_vdb is not None:
             try:

--- a/shared/vector_store.py
+++ b/shared/vector_store.py
@@ -10,9 +10,6 @@ Contrato externo (ChromaDB PersistentClient, >=0.5):
     de la coleccion). Default `cosine`.
   - No determinismo: ChromaDB 0.5-0.6 no expone `hnsw:random_seed`
     (deuda [#3](../CLAUDE.md#dt-3)).
-  - `LightRAGRetriever` accede a `_vector_store.collection_name` para
-    derivar nombres de Entity/Relationship/ChunkKeywords VDB (deuda
-    [#14](../CLAUDE.md#dt-14)).
 
 Schema del record insertado: `{id, embedding[D], document, metadata{
   reference_id?, title?, ...}}` donde `reference_id` es requerido por el


### PR DESCRIPTION
## Resumen

Cierre de dos deudas tecnicas estructurales en el motor LIGHT_RAG, con delta neto -7 lineas.

### dt-11 — `_get_neighbors_weighted` eliminado

Metodo en `KnowledgeGraph` sin callers en todo el codebase (verificado con grep global). `get_neighbors_ranked` cubre el caso de uso con mas informacion (`edge_weight + degree_centrality`). La hipotesis original de "refactorizar a iterador comun" se descarto al descubrir que el metodo era dead code.

**Resultado**: -23 lineas en `knowledge_graph.py`, cero cambios de API externa.

### dt-14 — Property publica `active_collection_name`

Antes: 3 sitios en `LightRAGRetriever` leian `self._vector_retriever._vector_store.collection_name` (atributo privado) para derivar los nombres de VDBs auxiliares (entities/relationships/chunk_keywords).

Ahora:
- `SimpleVectorRetriever.active_collection_name` (property) — devuelve el nombre real de la coleccion activa si esta inicializada, con fallback al nombre construido.
- `LightRAGRetriever._aux_vdb_collection_name(suffix)` — helper unico que valida estado y deriva `{base}_{suffix}`.
- 3 sitios consolidados a una linea cada uno.
- Docstring stale en `shared/vector_store.py` (que listaba el acceso privado como pattern tolerado) eliminado.

**Resultado**: +16/-23 en los 3 archivos afectados + docstring.

## Verificacion

- `python3 -c "import ast; ..."` OK en los 4 archivos modificados.
- `grep -r "_vector_store.collection_name"`: solo dentro de la property nueva (correcto).
- `grep -r "_get_neighbors_weighted"`: solo CLAUDE.md (entrada de deuda, pendiente de actualizar).

## Test plan

- [ ] Unit: la suite de `tests/test_knowledge_graph.py` no referenciaba el metodo eliminado (verificado).
- [ ] Integracion: ejecutar `LIGHT_RAG` end-to-end para verificar que las 3 VDBs auxiliares se construyen igual (requiere infra NIM del usuario).
- [ ] Post-merge: actualizar entradas `dt-11` y `dt-14` en `CLAUDE.md` para marcarlas como cerradas.

https://claude.ai/code/session_01SeA7CnL8bpqWA7JThEod3v