### PR TITLE
Fase 2: observables de filter pressure en canal chunk keywords (dt-17)

### DIFF
--- a/shared/retrieval/core.py
+++ b/shared/retrieval/core.py
@@ -180,6 +180,18 @@ class SimpleVectorRetriever(BaseRetriever):
         self.embedding_batch_size = embedding_batch_size
         self._vector_store: Any = None  # ChromaVectorStore, lazy import
 
+    @property
+    def active_collection_name(self) -> Optional[str]:
+        """Nombre real de la coleccion ChromaDB activa, o None si no indexado.
+
+        Consumidores externos (p.ej. LightRAGRetriever construyendo VDBs
+        auxiliares) deben usar esta property en vez de acceder a
+        `_vector_store.collection_name` directamente.
+        """
+        if self._vector_store is not None:
+            return self._vector_store.collection_name
+        return self.collection_name
+
     def _init_vector_store(self, collection_name: str) -> None:
         from shared.vector_store import ChromaStoreConfig, ChromaVectorStore
 

--- a/shared/retrieval/lightrag/knowledge_graph.py
+++ b/shared/retrieval/lightrag/knowledge_graph.py
@@ -282,30 +282,6 @@ class KnowledgeGraph:
         neighbor_vids = self._graph.neighbors(vid)
         return [self._graph.vs[nv]["name"] for nv in neighbor_vids]
 
-    def _get_neighbors_weighted(self, name: str) -> List[Tuple[str, float]]:
-        """Return neighbors with edge weight factor.
-
-        Weight = log(1 + unique_docs_on_edge). Co-occurrence edges (1 doc)
-        get ~0.69, strong LLM edges (10 docs) get ~2.40.
-
-        Returns:
-            List of (neighbor_name, weight_factor) tuples.
-        """
-        vid = self._name_to_vid.get(name)
-        if vid is None:
-            return []
-        result: List[Tuple[str, float]] = []
-        for eid in self._graph.incident(vid):
-            edge = self._graph.es[eid]
-            neighbor_vid = edge.target if edge.source == vid else edge.source
-            neighbor_name = self._graph.vs[neighbor_vid]["name"]
-            # Edge weight = unique docs mentioning this edge
-            relations = edge["relations"]
-            unique_docs = len({r.get("doc_id", "") for r in relations if r.get("doc_id")})
-            weight_factor = math.log1p(max(unique_docs, 1))
-            result.append((neighbor_name, weight_factor))
-        return result
-
     def get_neighbors_ranked(
         self, name: str, max_neighbors: int = 5,
     ) -> List[Dict[str, Any]]:

--- a/shared/retrieval/lightrag/retriever.py
+++ b/shared/retrieval/lightrag/retriever.py
@@ -150,6 +150,18 @@ class LightRAGRetriever(BaseRetriever):
         self._query_keywords_cache: OrderedDict[str, Tuple[List[str], List[str]]] = OrderedDict()
         self._cache_lock = threading.Lock()
 
+    def _aux_vdb_collection_name(self, suffix: str) -> str:
+        """Deriva el nombre de una VDB auxiliar (entities/relationships/chunk_keywords)
+        del nombre activo del ChromaVectorStore principal.
+        """
+        base = self._vector_retriever.active_collection_name
+        if not base:
+            raise RuntimeError(
+                "No se puede derivar nombre de VDB auxiliar: vector store "
+                "principal no tiene coleccion activa"
+            )
+        return f"{base}_{suffix}"
+
     def index_documents(
         self,
         documents: List[Dict[str, Any]],
@@ -426,9 +438,7 @@ class LightRAGRetriever(BaseRetriever):
         from shared.vector_store import ChromaVectorStore
         from langchain_core.documents import Document
 
-        # Collection name: {base}_entities para no colisionar con docs
-        base_name = self._vector_retriever._vector_store.collection_name
-        entity_collection_name = f"{base_name}_entities"
+        entity_collection_name = self._aux_vdb_collection_name("entities")
 
         # Limpiar VDB anterior si existe
         if self._entities_vdb is not None:
@@ -532,8 +542,7 @@ class LightRAGRetriever(BaseRetriever):
         from shared.vector_store import ChromaVectorStore
         from langchain_core.documents import Document
 
-        base_name = self._vector_retriever._vector_store.collection_name
-        rel_collection_name = f"{base_name}_relationships"
+        rel_collection_name = self._aux_vdb_collection_name("relationships")
 
         if self._relationships_vdb is not None:
             try:
@@ -625,8 +634,7 @@ class LightRAGRetriever(BaseRetriever):
         from shared.vector_store import ChromaVectorStore
         from langchain_core.documents import Document
 
-        base_name = self._vector_retriever._vector_store.collection_name
-        ck_collection_name = f"{base_name}_chunk_keywords"
+        ck_collection_name = self._aux_vdb_collection_name("chunk_keywords")
 
         if self._chunk_keywords_vdb is not None:
             try:

--- a/shared/retrieval/lightrag/retriever.py
+++ b/shared/retrieval/lightrag/retriever.py
@@ -676,7 +676,7 @@ class LightRAGRetriever(BaseRetriever):
         self,
         keywords: List[str],
         top_k: int,
-    ) -> List[Tuple[str, float]]:
+    ) -> Tuple[List[Tuple[str, float]], int]:
         """Resuelve query high_level keywords contra Chunk Keywords VDB
         (divergencia #10: canal adicional del path high-level).
 
@@ -685,16 +685,22 @@ class LightRAGRetriever(BaseRetriever):
         su mejor distancia (menor cosine distance = mas similar).
 
         Returns:
-            Lista de (doc_id, best_distance) ordenada por orden de
-            aparicion (primera keyword de la query domina); cada doc_id
-            aparece una sola vez con la mejor distancia observada.
+            Tupla (matches, distance_filtered):
+              - matches: lista de (doc_id, best_distance) ordenada por
+                orden de aparicion (primera keyword de la query domina);
+                cada doc_id una sola vez con la mejor distancia observada.
+              - distance_filtered: total de resultados descartados por
+                `_CHUNK_KEYWORDS_VDB_MAX_DISTANCE` (observable dt-17). Si
+                crece consistentemente respecto a `top_k * len(keywords)`,
+                el umbral esta cortando senal util.
         """
         if not self._chunk_keywords_vdb or not keywords:
-            return []
+            return [], 0
 
         best_distance: Dict[str, float] = {}
         first_seen: Dict[str, int] = {}
         seq = 0
+        distance_filtered = 0
         for keyword in keywords:
             kw = keyword.strip()
             if not kw:
@@ -711,6 +717,7 @@ class LightRAGRetriever(BaseRetriever):
                 continue
             for doc, distance in results:
                 if distance > self._CHUNK_KEYWORDS_VDB_MAX_DISTANCE:
+                    distance_filtered += 1
                     continue
                 doc_id = doc.metadata.get("doc_id", "")
                 if not doc_id:
@@ -724,10 +731,11 @@ class LightRAGRetriever(BaseRetriever):
                         seq += 1
 
         # Orden de aparicion (mantiene la semantica de rank de la query)
-        return sorted(
+        ordered = sorted(
             best_distance.items(),
             key=lambda kv: first_seen.get(kv[0], 1 << 30),
         )
+        return ordered, distance_filtered
 
     @staticmethod
     def _corpus_fingerprint(
@@ -949,15 +957,18 @@ class LightRAGRetriever(BaseRetriever):
         # Chunk Keywords VDB. Si el flag esta off o la VDB no existe,
         # resolved_chunk_matches queda vacio y no contribuye al scoring.
         resolved_chunk_matches: List[Tuple[str, float]] = []
+        chunk_keywords_distance_filtered = 0
         if (
             use_global
             and high_level
             and self.config.kg_chunk_keywords_enabled
             and self._chunk_keywords_vdb is not None
         ):
-            resolved_chunk_matches = self._resolve_chunks_via_keywords_vdb(
-                high_level,
-                top_k=self.config.kg_chunk_keywords_top_k,
+            resolved_chunk_matches, chunk_keywords_distance_filtered = (
+                self._resolve_chunks_via_keywords_vdb(
+                    high_level,
+                    top_k=self.config.kg_chunk_keywords_top_k,
+                )
             )
 
         doc_scores: Dict[str, float] = {}
@@ -1010,6 +1021,9 @@ class LightRAGRetriever(BaseRetriever):
             result.metadata["kg_entities"] = kg_entities
             result.metadata["kg_relations"] = resolved_relations
             result.metadata["kg_chunk_keyword_matches"] = len(resolved_chunk_matches)
+            result.metadata["kg_chunk_keywords_distance_filtered"] = (
+                chunk_keywords_distance_filtered
+            )
             with_nb, mean_nb = _neighbor_coverage_stats(kg_entities)
             result.metadata["kg_entities_with_neighbors"] = with_nb
             result.metadata["kg_mean_neighbors_per_entity"] = mean_nb
@@ -1045,6 +1059,9 @@ class LightRAGRetriever(BaseRetriever):
             result.metadata["kg_entities"] = kg_entities
             result.metadata["kg_relations"] = resolved_relations
             result.metadata["kg_chunk_keyword_matches"] = len(resolved_chunk_matches)
+            result.metadata["kg_chunk_keywords_distance_filtered"] = (
+                chunk_keywords_distance_filtered
+            )
             with_nb, mean_nb = _neighbor_coverage_stats(kg_entities)
             result.metadata["kg_entities_with_neighbors"] = with_nb
             result.metadata["kg_mean_neighbors_per_entity"] = mean_nb
@@ -1067,6 +1084,7 @@ class LightRAGRetriever(BaseRetriever):
                 "kg_entities": kg_entities,
                 "kg_relations": resolved_relations,
                 "kg_chunk_keyword_matches": len(resolved_chunk_matches),
+                "kg_chunk_keywords_distance_filtered": chunk_keywords_distance_filtered,
                 "kg_entities_with_neighbors": with_nb,
                 "kg_mean_neighbors_per_entity": mean_nb,
                 "kg_doc_scores": {did: s for did, s in ranked_doc_ids},

--- a/shared/retrieval/lightrag/triplet_extractor.py
+++ b/shared/retrieval/lightrag/triplet_extractor.py
@@ -154,6 +154,13 @@ class TripletExtractor:
             # Divergencia #10: chunk high-level keywords por doc
             "docs_with_keywords": 0,
             "total_chunk_keywords": 0,
+            # Observables de filtros hardcoded (dt-17): si estos contadores
+            # son altos respecto a total_chunk_keywords, los defaults
+            # (MIN/MAX_CHUNK_KEYWORD_LEN, MAX_CHUNK_KEYWORDS_PER_DOC) estan
+            # recortando senal util. Exponer al .env si se observa.
+            "chunk_keywords_rejected_len": 0,
+            "chunk_keywords_dropped_by_cap": 0,
+            "docs_chunk_keywords_capped": 0,
         }
 
     def get_stats(self) -> Dict[str, int]:
@@ -277,20 +284,28 @@ class TripletExtractor:
         # Divergencia #10: chunk high-level keywords
         chunk_keywords: List[str] = []
         seen_lower: set = set()
+        cap_hit = False
         for k in data.get("high_level_keywords", []):
             if not isinstance(k, str):
                 continue
             kw = k.strip()
             if len(kw) < MIN_CHUNK_KEYWORD_LEN or len(kw) > MAX_CHUNK_KEYWORD_LEN:
+                self._stats["chunk_keywords_rejected_len"] += 1
                 continue
             # Dedup case-insensitive preservando el primer casing visto
             key = kw.lower()
             if key in seen_lower:
                 continue
             seen_lower.add(key)
-            chunk_keywords.append(kw)
             if len(chunk_keywords) >= MAX_CHUNK_KEYWORDS_PER_DOC:
-                break
+                # Seguimos iterando para contar cuantas keywords validas
+                # perdemos por el cap (observable dt-17).
+                self._stats["chunk_keywords_dropped_by_cap"] += 1
+                cap_hit = True
+                continue
+            chunk_keywords.append(kw)
+        if cap_hit:
+            self._stats["docs_chunk_keywords_capped"] += 1
 
         return entities, relations, chunk_keywords
 

--- a/shared/vector_store.py
+++ b/shared/vector_store.py
@@ -10,9 +10,6 @@ Contrato externo (ChromaDB PersistentClient, >=0.5):
     de la coleccion). Default `cosine`.
   - No determinismo: ChromaDB 0.5-0.6 no expone `hnsw:random_seed`
     (deuda [#3](../CLAUDE.md#dt-3)).
-  - `LightRAGRetriever` accede a `_vector_store.collection_name` para
-    derivar nombres de Entity/Relationship/ChunkKeywords VDB (deuda
-    [#14](../CLAUDE.md#dt-14)).
 
 Schema del record insertado: `{id, embedding[D], document, metadata{
   reference_id?, title?, ...}}` donde `reference_id` es requerido por el

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -93,6 +93,10 @@ def make_extractor(mock_llm=None, max_text_chars=3000, batch_size=64):
         "total_entities": 0, "total_relations": 0,
         # Divergencia #10
         "docs_with_keywords": 0, "total_chunk_keywords": 0,
+        # Observables dt-17
+        "chunk_keywords_rejected_len": 0,
+        "chunk_keywords_dropped_by_cap": 0,
+        "docs_chunk_keywords_capped": 0,
     }
     return ext
 

--- a/tests/test_chunk_keywords_retrieval.py
+++ b/tests/test_chunk_keywords_retrieval.py
@@ -280,6 +280,8 @@ def test_chunk_keywords_distance_threshold_filters():
     assert result.doc_ids == ["close"]
     assert "far" not in result.doc_ids
     assert result.metadata["kg_chunk_keyword_matches"] == 1
+    # dt-17: observable de filter pressure
+    assert result.metadata["kg_chunk_keywords_distance_filtered"] == 1
 
 
 # =============================================================================

--- a/tests/test_triplet_extractor.py
+++ b/tests/test_triplet_extractor.py
@@ -430,6 +430,30 @@ def test_chunk_keywords_no_keywords_no_stats_bump():
     assert stats["total_chunk_keywords"] == 0
 
 
+def test_chunk_keywords_filter_observables_dt17():
+    """dt-17: contadores de keywords rechazadas por length y por cap."""
+    ext = make_extractor()
+    # 12 keywords validas + 1 too-short + 1 too-long => se acumulan
+    # 2 rechazos por length, el cap de 10 deja caer 2 adicionales.
+    long_kw = "a" * 100
+    keywords_in = (
+        ["x", long_kw]
+        + [f"theme {i:02d}" for i in range(12)]
+    )
+    raw = (
+        '{"entities": [], "relations": [], '
+        f'"high_level_keywords": {keywords_in!r}'
+        '}'
+    ).replace("'", '"')
+    _, _, keywords = ext._parse_extraction_json(raw, "doc1")
+    assert len(keywords) == 10  # cap activo
+
+    stats = ext.get_stats()
+    assert stats["chunk_keywords_rejected_len"] == 2  # "x" y long_kw
+    assert stats["chunk_keywords_dropped_by_cap"] == 2  # 12 - 10
+    assert stats["docs_chunk_keywords_capped"] == 1
+
+
 # =============================================================================
 # TE17-TE21: Estadisticas de extraccion
 # =============================================================================


### PR DESCRIPTION
## Resumen

Instrumenta los 3 gates hardcoded del canal chunk keywords (divergencia #10) para decidir empiricamente si parametrizarlos al `.env` en Fase 3.

**No es net-delete** (+63 lineas netas). Es instrumentacion deliberada — observabilidad previa a la decision de parametrizar para no exponer al `.env` sin datos de run real.

## Gates instrumentados

| Gate | Ubicacion | Default | Counter nuevo |
|---|---|---|---|
| `MIN/MAX_CHUNK_KEYWORD_LEN` | `triplet_extractor.py` | `2/80` | `chunk_keywords_rejected_len` |
| `MAX_CHUNK_KEYWORDS_PER_DOC` | `triplet_extractor.py` | `10` | `chunk_keywords_dropped_by_cap` + `docs_chunk_keywords_capped` |
| `_CHUNK_KEYWORDS_VDB_MAX_DISTANCE` | `retriever.py` | `0.8` | `kg_chunk_keywords_distance_filtered` (per-query) |

## Cambios de API interna

- `_resolve_chunks_via_keywords_vdb(...)` ahora devuelve `Tuple[List[Tuple[str, float]], int]` en vez de solo la lista. El segundo elemento es el total de resultados rechazados por el threshold de distancia.
- Unico caller del metodo actualizado. Campo nuevo propagado a los 3 retrieval_metadata sites (no_doc_ids fallback, docs_not_in_store fallback, happy path).
- `TripletExtractor._stats` dict ampliado con 3 claves nuevas; inicializacion extendida en `tests/helpers.py`.

## Cambio de semantica minor (extraction)

Antes, al alcanzar `MAX_CHUNK_KEYWORDS_PER_DOC`, el loop hacia `break`. Ahora continua iterando para contar el excedente (necesario para el observable). El set de keywords aceptadas no cambia — siguen siendo las primeras 10 validas.

## Verificacion

- `pytest tests/ -x -q --ignore=tests/integration`: **500 passed, 6 skipped**.
- Tests nuevos:
  - `test_chunk_keywords_filter_observables_dt17` — extraction-side (length + cap).
  - Extension de CK7 (`test_chunk_keywords_distance_threshold_filters`) — asserta `kg_chunk_keywords_distance_filtered == 1`.

## Criterios observables (para run real post-merge)

Despues del proximo run LIGHT_RAG, revisar los stats del extractor y las retrieval_metadata agregadas:

- **Signal low (defaults OK)**: `chunk_keywords_rejected_len / total_chunk_keywords < 5%`, `docs_chunk_keywords_capped / docs_with_keywords < 5%`, mediana de `kg_chunk_keywords_distance_filtered` per-query `< 20%` del total inspeccionado.
- **Signal high (Fase 3 debe parametrizar)**: cualquiera de los tres excede sus respectivos thresholds → exponer constantes al `.env` como `KG_CHUNK_KEYWORD_MIN/MAX_LEN`, `KG_MAX_CHUNK_KEYWORDS_PER_DOC`, `KG_CHUNK_KEYWORDS_VDB_MAX_DISTANCE`.

## Test plan

- [ ] Unit tests: OK (500 passed).
- [ ] Post-merge: usuario ejecuta 1 run LIGHT_RAG real y recupera stats (logs de extractor + `jq` sobre `query_results[].retrieval_metadata.kg_chunk_keywords_distance_filtered`).
- [ ] Fase 3: decidir con datos si parametrizar o cerrar dt-17 declarandolo inerte.

https://claude.ai/code/session_01SeA7CnL8bpqWA7JThEod3v