### PR TITLE
Trim boilerplate en tests consolidados (-170 lineas)

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,43 +1,26 @@
-"""
-Tests unitarios para MinIOLoader.
+"""Tests unitarios para MinIOLoader."""
 
-Cobertura:
-  LO1. check_connection exitosa
-  LO2. check_connection falla
-  LO3-LO12. _populate_from_dataframes: queries, corpus, qrels, edge cases
-            (None/empty, answer_type inferido, question_type metadata,
-             comparison auto-conversion)
-  LO13. load_dataset con error retorna LoadedDataset con status error
-"""
-
-from unittest.mock import MagicMock, patch
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from shared.types import (
-    LoadedDataset,
-    DatasetType,
-    MetricType,
-)
+import pytest
+
 from sandbox_mteb.config import MinIOStorageConfig
+from sandbox_mteb.loader import MinIOLoader
+from shared.types import DatasetType, LoadedDataset, MetricType
 
-
-# =============================================================================
-# Helpers
-# =============================================================================
 
 class _FakeClientError(Exception):
-    """Excepcion real que simula botocore.exceptions.ClientError.
+    """Simula botocore.exceptions.ClientError. conftest mockea botocore
+    como MagicMock y `except MagicMock` no funciona."""
 
-    Necesaria porque conftest.py mockea botocore como MagicMock cuando
-    no esta instalado, y `except MagicMock` no funciona en Python.
-    """
     def __init__(self, error_response, operation_name):
         self.response = error_response
         self.operation_name = operation_name
         super().__init__(f"{operation_name}: {error_response}")
 
 
-def _make_storage_config():
+def _storage_config():
     return MinIOStorageConfig(
         minio_endpoint="http://fake:9000",
         minio_access_key="test",
@@ -49,8 +32,6 @@ def _make_storage_config():
 
 
 class _MockDataFrame:
-    """DataFrame minimo compatible con iterrows()."""
-
     def __init__(self, rows):
         self._rows = rows
 
@@ -63,13 +44,11 @@ class _MockDataFrame:
 
 
 class _MockRow(dict):
-    """Row que soporta .get() como dict."""
-
     def get(self, key, default=""):
         return super().get(key, default)
 
 
-def _make_empty_result():
+def _empty_result():
     return LoadedDataset(
         name="test",
         dataset_type=DatasetType.HYBRID,
@@ -77,31 +56,32 @@ def _make_empty_result():
     )
 
 
+def _populate(queries, corpus=None, qrels=None):
+    result = _empty_result()
+    MinIOLoader._populate_from_dataframes(
+        result,
+        _MockDataFrame(queries) if queries is not None else None,
+        _MockDataFrame(corpus) if corpus is not None else None,
+        _MockDataFrame(qrels) if qrels is not None else None,
+    )
+    return result
+
+
 # =============================================================================
-# LO1: check_connection exitosa
+# check_connection
 # =============================================================================
 
 @patch("sandbox_mteb.loader.boto3")
 def test_check_connection_success(mock_boto3):
-    """head_bucket sin error -> True."""
     mock_client = MagicMock()
     mock_boto3.client.return_value = mock_client
-
-    from sandbox_mteb.loader import MinIOLoader
-    loader = MinIOLoader(_make_storage_config())
-    assert loader.check_connection() is True
-    # Verify head_bucket was called (connection was actually checked)
+    assert MinIOLoader(_storage_config()).check_connection() is True
     mock_client.head_bucket.assert_called_once()
 
-
-# =============================================================================
-# LO2: check_connection falla
-# =============================================================================
 
 @patch("sandbox_mteb.loader.boto3")
 @patch("sandbox_mteb.loader.ClientError", _FakeClientError)
 def test_check_connection_failure(mock_boto3):
-    """head_bucket lanza ClientError -> False."""
     mock_client = MagicMock()
     mock_client.head_bucket.side_effect = _FakeClientError(
         {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadBucket"
@@ -109,48 +89,33 @@ def test_check_connection_failure(mock_boto3):
     mock_boto3.client.return_value = mock_client
 
     from tests.helpers import make_loader
-    loader = make_loader(mock_client=mock_client)
-
-    assert loader.check_connection() is False
+    assert make_loader(mock_client=mock_client).check_connection() is False
 
 
 # =============================================================================
-# LO3-LO12: _populate_from_dataframes (queries, corpus, qrels, edge cases)
+# _populate_from_dataframes
 # =============================================================================
 
 def test_populate_basic():
-    """Popula queries, corpus y qrels correctamente."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    queries_df = _MockDataFrame([
-        {"query_id": "q1", "text": "What is AI?", "answer": "Artificial Intelligence",
-         "answer_type": "text", "question_type": "bridge", "level": "easy"},
-        {"query_id": "q2", "text": "Is Python good?", "answer": "yes",
-         "answer_type": "label", "question_type": "comparison", "level": "medium"},
-    ])
-    corpus_df = _MockDataFrame([
-        {"doc_id": "d1", "title": "AI Intro", "text": "AI is the simulation of intelligence."},
-        {"doc_id": "d2", "title": "Python", "text": "Python is a programming language."},
-    ])
-    qrels_df = _MockDataFrame([
-        {"query_id": "q1", "doc_id": "d1"},
-        {"query_id": "q2", "doc_id": "d2"},
-    ])
-
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, queries_df, corpus_df, qrels_df)
-
-    assert len(result.queries) == 2
-    assert result.queries[0].query_id == "q1"
+    result = _populate(
+        queries=[
+            {"query_id": "q1", "text": "What is AI?", "answer": "Artificial Intelligence",
+             "answer_type": "text", "question_type": "bridge", "level": "easy"},
+            {"query_id": "q2", "text": "Is Python good?", "answer": "yes",
+             "answer_type": "label", "question_type": "comparison", "level": "medium"},
+        ],
+        corpus=[
+            {"doc_id": "d1", "title": "AI Intro", "text": "AI is the simulation of intelligence."},
+            {"doc_id": "d2", "title": "Python", "text": "Python is a programming language."},
+        ],
+        qrels=[{"query_id": "q1", "doc_id": "d1"}, {"query_id": "q2", "doc_id": "d2"}],
+    )
+    assert [q.query_id for q in result.queries] == ["q1", "q2"]
     assert result.queries[0].query_text == "What is AI?"
     assert result.queries[0].expected_answer == "Artificial Intelligence"
-    assert result.queries[0].answer_type == "text"
-    assert result.queries[1].answer_type == "label"
-
-    assert len(result.corpus) == 2
+    assert [q.answer_type for q in result.queries] == ["text", "label"]
     assert result.corpus["d1"].title == "AI Intro"
     assert "simulation" in result.corpus["d1"].content
-
     assert result.queries[0].relevant_doc_ids == ["d1"]
     assert result.queries[1].relevant_doc_ids == ["d2"]
     assert result.total_queries == 2
@@ -158,152 +123,85 @@ def test_populate_basic():
 
 
 def test_populate_multiple_qrels_per_query():
-    """Una query con multiples docs relevantes."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    queries_df = _MockDataFrame([{"query_id": "q1", "text": "Multi-hop question"}])
-    corpus_df = _MockDataFrame([
-        {"doc_id": "d1", "title": "Doc A", "text": "Content A"},
-        {"doc_id": "d2", "title": "Doc B", "text": "Content B"},
-    ])
-    qrels_df = _MockDataFrame([
-        {"query_id": "q1", "doc_id": "d1"},
-        {"query_id": "q1", "doc_id": "d2"},
-    ])
-
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, queries_df, corpus_df, qrels_df)
+    result = _populate(
+        queries=[{"query_id": "q1", "text": "Multi-hop"}],
+        corpus=[{"doc_id": "d1", "title": "A", "text": "CA"},
+                {"doc_id": "d2", "title": "B", "text": "CB"}],
+        qrels=[{"query_id": "q1", "doc_id": "d1"}, {"query_id": "q1", "doc_id": "d2"}],
+    )
     assert set(result.queries[0].relevant_doc_ids) == {"d1", "d2"}
 
 
-def test_populate_none_dataframes_no_crash():
-    """DataFrames None no causan error."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, None, None, None)
-    assert len(result.queries) == 0
-    assert len(result.corpus) == 0
-
-
-def test_populate_empty_dataframes():
-    """DataFrames vacios producen listas vacias."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(
-        result, _MockDataFrame([]), _MockDataFrame([]), _MockDataFrame([])
-    )
+@pytest.mark.parametrize("queries,corpus,qrels", [
+    (None, None, None),
+    ([], [], []),
+])
+def test_populate_empty_or_none_no_crash(queries, corpus, qrels):
+    result = _populate(queries, corpus, qrels)
     assert len(result.queries) == 0
     assert len(result.corpus) == 0
 
 
 def test_populate_answer_type_inferred_when_missing():
-    """Si answer_type ausente pero answer presente, se infiere 'text'."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    queries_df = _MockDataFrame([
-        {"query_id": "q1", "text": "Question?", "answer": "Some answer"},
-    ])
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, queries_df, _MockDataFrame([]), None)
+    """answer presente sin answer_type → 'text'."""
+    result = _populate([{"query_id": "q1", "text": "Q?", "answer": "Some answer"}], [])
     assert result.queries[0].answer_type == "text"
 
 
 def test_populate_no_answer_no_answer_type():
-    """Sin answer ni answer_type, expected_answer es None."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    queries_df = _MockDataFrame([{"query_id": "q1", "text": "Question?"}])
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, queries_df, _MockDataFrame([]), None)
+    result = _populate([{"query_id": "q1", "text": "Q?"}], [])
     assert result.queries[0].expected_answer is None
     assert result.queries[0].answer_type is None
 
 
-def test_populate_question_type_metadata():
-    """question_type se guarda en metadata."""
-    from sandbox_mteb.loader import MinIOLoader
+@pytest.mark.parametrize("row,expected_type", [
+    ({"query_id": "q1", "text": "Q?", "question_type": "bridge", "level": "hard"}, "bridge"),
+    ({"query_id": "q1", "text": "Q?", "type": "comparison"}, "comparison"),
+])
+def test_populate_question_type_metadata(row, expected_type):
+    """question_type (o fallback a 'type') se guarda en metadata."""
+    result = _populate([row], [])
+    assert result.queries[0].metadata["question_type"] == expected_type
 
-    queries_df = _MockDataFrame([
-        {"query_id": "q1", "text": "Q?", "question_type": "bridge", "level": "hard"},
-    ])
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, queries_df, _MockDataFrame([]), None)
-    assert result.queries[0].metadata["question_type"] == "bridge"
+
+def test_populate_question_type_level_captured():
+    result = _populate(
+        [{"query_id": "q1", "text": "Q?", "question_type": "bridge", "level": "hard"}], []
+    )
     assert result.queries[0].metadata["level"] == "hard"
 
 
-def test_populate_question_type_fallback_to_type_field():
-    """Si question_type no existe, usa campo 'type'."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    queries_df = _MockDataFrame([
-        {"query_id": "q1", "text": "Q?", "type": "comparison"},
-    ])
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, queries_df, _MockDataFrame([]), None)
-    assert result.queries[0].metadata["question_type"] == "comparison"
-
-
 def test_populate_query_without_qrels_empty_relevant_ids():
-    """Query sin qrels correspondiente tiene relevant_doc_ids vacio."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    queries_df = _MockDataFrame([{"query_id": "q1", "text": "Orphan query"}])
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(
-        result, queries_df, _MockDataFrame([]), _MockDataFrame([])
-    )
+    result = _populate([{"query_id": "q1", "text": "Orphan"}], [], [])
     assert result.queries[0].relevant_doc_ids == []
 
 
-def test_populate_comparison_query_forces_label():
-    """question_type=comparison fuerza answer_type=label; ya-label es idempotente."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    queries_df = _MockDataFrame([
-        {"query_id": "q1", "text": "Is A taller?", "answer": "yes",
-         "answer_type": "text", "question_type": "comparison"},
-        {"query_id": "q2", "text": "Is B taller?", "answer": "no",
-         "answer_type": "label", "question_type": "comparison"},
-    ])
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, queries_df, _MockDataFrame([]), None)
-    assert result.queries[0].answer_type == "label"
-    assert result.queries[1].answer_type == "label"
-
-
-def test_populate_non_comparison_preserves_answer_type():
-    """question_type!=comparison no toca answer_type."""
-    from sandbox_mteb.loader import MinIOLoader
-
-    queries_df = _MockDataFrame([
-        {"query_id": "q1", "text": "What is X?", "answer": "some answer",
-         "answer_type": "text", "question_type": "bridge"},
-    ])
-    result = _make_empty_result()
-    MinIOLoader._populate_from_dataframes(result, queries_df, _MockDataFrame([]), None)
-    assert result.queries[0].answer_type == "text"
+@pytest.mark.parametrize("question_type,initial_answer_type,expected", [
+    ("comparison", "text", "label"),   # comparison fuerza label
+    ("comparison", "label", "label"),  # idempotente
+    ("bridge", "text", "text"),        # no-comparison preserva
+])
+def test_populate_comparison_forces_label(question_type, initial_answer_type, expected):
+    result = _populate([{
+        "query_id": "q1", "text": "Q?", "answer": "a",
+        "answer_type": initial_answer_type, "question_type": question_type,
+    }], [])
+    assert result.queries[0].answer_type == expected
 
 
 # =============================================================================
-# LO13: load_dataset con error
+# load_dataset error path
 # =============================================================================
 
 @patch("sandbox_mteb.loader.boto3")
 @patch("sandbox_mteb.loader.ClientError", _FakeClientError)
 def test_load_dataset_download_error(mock_boto3):
-    """Error en descarga -> LoadedDataset con status error."""
     mock_client = MagicMock()
     mock_client.get_object.side_effect = _FakeClientError(
         {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}}, "GetObject"
     )
     mock_boto3.client.return_value = mock_client
 
-    from sandbox_mteb.loader import MinIOLoader
-    loader = MinIOLoader(_make_storage_config())
-
-    result = loader.load_dataset("nonexistent_dataset", use_cache=False)
+    result = MinIOLoader(_storage_config()).load_dataset("nonexistent", use_cache=False)
     assert result.load_status == "error"
     assert result.error_message is not None

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,34 +1,18 @@
-"""
-Tests unitarios para shared/retrieval/reranker.py (Audit Fase 3 — A3.4).
-
-Cobertura:
-  K1. rerank() con resultado vacio retorna mismo resultado
-  K2. rerank() ordena por relevance_score descendente
-  K3. rerank() trunca a top_n
-  K4. rerank() preserva vector_scores originales
-  K5. rerank() en error retorna fallback sin rerank
-  K6. rerank() metadata incluye reranked=True/False
-"""
+"""Tests unitarios para shared/retrieval/reranker.py."""
 
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from shared.retrieval.core import RetrievalResult, RetrievalStrategy
 
 
 def _make_reranker():
-    """Crea CrossEncoderReranker con mock de NVIDIARerank."""
     from shared.retrieval.reranker import CrossEncoderReranker
 
     with patch("shared.retrieval.reranker.NVIDIARerank") as MockRerank:
-        mock_instance = MagicMock()
-        MockRerank.return_value = mock_instance
-        reranker = CrossEncoderReranker(
-            base_url="http://fake:8000/v1",
-            model_name="test-reranker",
+        MockRerank.return_value = MagicMock()
+        return CrossEncoderReranker(
+            base_url="http://fake:8000/v1", model_name="test-reranker"
         )
-    return reranker
 
 
 def _make_result(n=5, with_vector_scores=True) -> RetrievalResult:
@@ -43,148 +27,96 @@ def _make_result(n=5, with_vector_scores=True) -> RetrievalResult:
     )
 
 
-def _make_reranked_doc(doc_id, content, score):
-    """Simula un Document retornado por compress_documents."""
+def _make_reranked_doc(doc_id, score, with_score=True):
     doc = MagicMock()
-    doc.page_content = content
-    doc.metadata = {"doc_id": doc_id, "relevance_score": score}
+    doc.page_content = f"content {doc_id}"
+    doc.metadata = {"doc_id": doc_id}
+    if with_score:
+        doc.metadata["relevance_score"] = score
     return doc
 
 
-class TestRerankEmpty:
-    """K1: resultado vacio."""
-
-    def test_empty_result_passthrough(self):
-        reranker = _make_reranker()
-        empty = RetrievalResult(
-            doc_ids=[], contents=[], scores=[],
-            strategy_used=RetrievalStrategy.SIMPLE_VECTOR,
-        )
-        result = reranker.rerank("query", empty, top_n=5)
-        assert result.doc_ids == []
+def test_empty_result_passthrough():
+    empty = RetrievalResult(
+        doc_ids=[], contents=[], scores=[],
+        strategy_used=RetrievalStrategy.SIMPLE_VECTOR,
+    )
+    assert _make_reranker().rerank("query", empty, top_n=5).doc_ids == []
 
 
-class TestRerankOrdering:
-    """K2: ordenamiento por relevance_score."""
-
-    def test_sorts_by_relevance_descending(self):
-        reranker = _make_reranker()
-        original = _make_result(3)
-
-        # Simulate reranker returning docs in wrong order
-        reranker._reranker.compress_documents.return_value = [
-            _make_reranked_doc("d2", "content d2", 0.3),
-            _make_reranked_doc("d0", "content d0", 0.9),
-            _make_reranked_doc("d1", "content d1", 0.6),
-        ]
-
-        result = reranker.rerank("query", original, top_n=3)
-        assert result.doc_ids == ["d0", "d1", "d2"]
-        assert result.scores == [0.9, 0.6, 0.3]
+def test_sorts_by_relevance_descending():
+    reranker = _make_reranker()
+    reranker._reranker.compress_documents.return_value = [
+        _make_reranked_doc("d2", 0.3),
+        _make_reranked_doc("d0", 0.9),
+        _make_reranked_doc("d1", 0.6),
+    ]
+    result = reranker.rerank("query", _make_result(3), top_n=3)
+    assert result.doc_ids == ["d0", "d1", "d2"]
+    assert result.scores == [0.9, 0.6, 0.3]
 
 
-class TestRerankTopN:
-    """K3: truncamiento a top_n."""
-
-    def test_truncates_to_top_n(self):
-        reranker = _make_reranker()
-        original = _make_result(5)
-
-        reranker._reranker.compress_documents.return_value = [
-            _make_reranked_doc(f"d{i}", f"content d{i}", 1.0 - i * 0.1)
-            for i in range(5)
-        ]
-
-        result = reranker.rerank("query", original, top_n=2)
-        assert len(result.doc_ids) == 2
+def test_truncates_to_top_n():
+    reranker = _make_reranker()
+    reranker._reranker.compress_documents.return_value = [
+        _make_reranked_doc(f"d{i}", 1.0 - i * 0.1) for i in range(5)
+    ]
+    assert len(reranker.rerank("query", _make_result(5), top_n=2).doc_ids) == 2
 
 
-class TestRerankVectorScores:
-    """K4: preserva vector_scores."""
-
-    def test_preserves_original_vector_scores(self):
-        reranker = _make_reranker()
-        original = _make_result(3, with_vector_scores=True)
-
-        reranker._reranker.compress_documents.return_value = [
-            _make_reranked_doc("d1", "content d1", 0.9),
-            _make_reranked_doc("d0", "content d0", 0.8),
-        ]
-
-        result = reranker.rerank("query", original, top_n=2)
-        # d1 had vector_score 0.85, d0 had 0.9
-        assert result.vector_scores is not None
-        assert result.vector_scores[0] == original.vector_scores[1]  # d1's score
-        assert result.vector_scores[1] == original.vector_scores[0]  # d0's score
-
-    def test_no_vector_scores_returns_none(self):
-        reranker = _make_reranker()
-        original = _make_result(2, with_vector_scores=False)
-
-        reranker._reranker.compress_documents.return_value = [
-            _make_reranked_doc("d0", "content d0", 0.9),
-        ]
-
-        result = reranker.rerank("query", original, top_n=1)
-        assert result.vector_scores is None
+def test_preserves_original_vector_scores():
+    reranker = _make_reranker()
+    original = _make_result(3, with_vector_scores=True)
+    reranker._reranker.compress_documents.return_value = [
+        _make_reranked_doc("d1", 0.9),
+        _make_reranked_doc("d0", 0.8),
+    ]
+    result = reranker.rerank("query", original, top_n=2)
+    assert result.vector_scores == [original.vector_scores[1], original.vector_scores[0]]
 
 
-class TestRerankSortEdges:
-    """Ordering edge cases (scores identicos / sin relevance_score)."""
-
-    def test_identical_scores(self):
-        """Docs con scores identicos no producen error."""
-        reranker = _make_reranker()
-        reranker._reranker.compress_documents.return_value = [
-            _make_reranked_doc("a", "c_a", 0.7),
-            _make_reranked_doc("b", "c_b", 0.7),
-            _make_reranked_doc("c", "c_c", 0.7),
-        ]
-        result = reranker.rerank("query", _make_result(3), top_n=3)
-        assert len(result.doc_ids) == 3
-        assert all(s == 0.7 for s in result.scores)
-
-    def test_missing_relevance_score(self):
-        """Doc sin relevance_score en metadata -> default 0.0, queda al final."""
-        no_score = MagicMock()
-        no_score.page_content = "c_no_score"
-        no_score.metadata = {"doc_id": "no_score"}  # sin relevance_score
-        reranker = _make_reranker()
-        reranker._reranker.compress_documents.return_value = [
-            no_score,
-            _make_reranked_doc("high", "c_high", 0.9),
-            _make_reranked_doc("mid", "c_mid", 0.5),
-        ]
-        result = reranker.rerank("query", _make_result(3), top_n=3)
-        assert result.doc_ids[-1] == "no_score"
-        assert result.scores[-1] == 0.0
+def test_no_vector_scores_returns_none():
+    reranker = _make_reranker()
+    reranker._reranker.compress_documents.return_value = [_make_reranked_doc("d0", 0.9)]
+    result = reranker.rerank("query", _make_result(2, with_vector_scores=False), top_n=1)
+    assert result.vector_scores is None
 
 
-class TestRerankError:
-    """K5/K6: error fallback y metadata."""
+def test_identical_scores():
+    reranker = _make_reranker()
+    reranker._reranker.compress_documents.return_value = [
+        _make_reranked_doc(d, 0.7) for d in ("a", "b", "c")
+    ]
+    result = reranker.rerank("query", _make_result(3), top_n=3)
+    assert len(result.doc_ids) == 3
+    assert all(s == 0.7 for s in result.scores)
 
-    def test_error_returns_fallback(self):
-        reranker = _make_reranker()
-        original = _make_result(5)
 
-        reranker._reranker.compress_documents.side_effect = RuntimeError("NIM down")
+def test_missing_relevance_score_sinks_to_end():
+    reranker = _make_reranker()
+    reranker._reranker.compress_documents.return_value = [
+        _make_reranked_doc("no_score", 0.0, with_score=False),
+        _make_reranked_doc("high", 0.9),
+        _make_reranked_doc("mid", 0.5),
+    ]
+    result = reranker.rerank("query", _make_result(3), top_n=3)
+    assert result.doc_ids[-1] == "no_score"
+    assert result.scores[-1] == 0.0
 
-        result = reranker.rerank("query", original, top_n=3)
-        # Fallback: top_n from original
-        assert len(result.doc_ids) == 3
-        assert result.doc_ids == ["d0", "d1", "d2"]
-        assert result.metadata["reranked"] is False
-        assert "NIM down" in result.metadata["rerank_error"]
 
-    def test_success_metadata(self):
-        reranker = _make_reranker()
-        original = _make_result(2)
+def test_error_returns_fallback():
+    reranker = _make_reranker()
+    reranker._reranker.compress_documents.side_effect = RuntimeError("NIM down")
+    result = reranker.rerank("query", _make_result(5), top_n=3)
+    assert result.doc_ids == ["d0", "d1", "d2"]
+    assert result.metadata["reranked"] is False
+    assert "NIM down" in result.metadata["rerank_error"]
 
-        reranker._reranker.compress_documents.return_value = [
-            _make_reranked_doc("d0", "content d0", 0.9),
-        ]
 
-        result = reranker.rerank("query", original, top_n=1)
-        assert result.metadata["reranked"] is True
-        assert result.metadata["reranker_model"] == "test-reranker"
-        assert "rerank_time_ms" in result.metadata
+def test_success_metadata():
+    reranker = _make_reranker()
+    reranker._reranker.compress_documents.return_value = [_make_reranked_doc("d0", 0.9)]
+    result = reranker.rerank("query", _make_result(2), top_n=1)
+    assert result.metadata["reranked"] is True
+    assert result.metadata["reranker_model"] == "test-reranker"
+    assert "rerank_time_ms" in result.metadata


### PR DESCRIPTION
## Summary

Trim del boilerplate que quedo tras absorber tests DT/DTM en PR #61.

**`test_loader.py`** (309 → 207):
- `from sandbox_mteb.loader import MinIOLoader` movido a modulo-level (antes repetido en 12 funciones)
- Helper `_populate()` encapsula la construccion de `_MockDataFrame` + invocacion, reemplaza ~6 lineas por test
- `@pytest.mark.parametrize` fusiona: None/empty dataframes (2 casos), variantes de `question_type` (2 casos), comparison → label auto-conversion (3 casos)
- Docstrings redundantes (que repetian el nombre del test) eliminados

**`test_reranker.py`** (190 → 122):
- 6 clases wrapper de 1-2 tests cada una aplanadas a funciones top-level
- `_make_reranked_doc()` gana flag `with_score=` que reemplaza el MagicMock inline que existia solo para `test_missing_relevance_score`
- Docstrings de clase cosmeticos retirados

## Test plan
- [x] `pytest tests/ -x -q --ignore=tests/integration` → 448 passed, 6 skipped (+2 vs baseline por parametrize expansion)

https://claude.ai/code/session_01SeA7CnL8bpqWA7JThEod3v