### PR TITLE
docs: registrar run SIMPLE_VECTOR P0 y purgar referencias historicas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Tres condiciones cumplidas simultaneamente:
 2. **Ejecucion estable**: `kg_synthesis_stats.fallback_rate = 2.86%` (< 10% umbral), `judge.default_return_rate = 0%`, `retrieval_metadata.kg_fallback = null` en 35/35 queries, `queries_failed = 0`.
 3. **Funcionalidades extra documentadas**: cache de KG, fallbacks ante errores LLM/igraph, instrumentacion de timing (queue/LLM split) — adaptaciones operativas, no sustitutos de piezas del paper.
 
-**Config validada** para runs LIGHT_RAG en infra actual (defaults en `sandbox_mteb/env.example`, marcados `[PRE-P0 VALIDATED]`):
+**Config recomendada** para runs LIGHT_RAG en infra actual (defaults en `sandbox_mteb/env.example`):
 - `NIM_MAX_CONCURRENT_REQUESTS=32`
 - `KG_SYNTHESIS_MAX_CHARS=50000`
 - `KG_SYNTHESIS_TIMEOUT_S=180`
@@ -248,6 +248,14 @@ Tres condiciones cumplidas simultaneamente:
 **Criterio de exito**: delta `LIGHT_RAG > SIMPLE_VECTOR` en la metrica principal del benchmark, distinguible del ruido (seed×LLM), con signo consistente con el paper.
 
 **Criterio de fallo**: deltas dentro del ruido o invertidos → debug (¿synthesis llega al generador? ¿KG se construye? ¿indexacion falla silenciosamente?), no avance a P2/P3.
+
+**Runs en `./results/`** (estado factual, sin interpretacion):
+
+| Run ID | Estrategia | Archivos |
+|---|---|---|
+| `mteb_hotpotqa_20260507_095501` | `SIMPLE_VECTOR` | `results/mteb_hotpotqa_20260507_095501.json`, `results/console_log_simple_vector_20260507_095501.txt` |
+
+Pendiente: run gemelo `LIGHT_RAG` sobre la misma config para comparativa A/B. **No interpretar metricas en aislamiento** — cualquier numero de un run individual sin su contraparte es senal incompleta.
 
 ### P2 — Experimento 3: catalogo especializado · futuro, contingente a P0
 

--- a/sandbox_mteb/env.example
+++ b/sandbox_mteb/env.example
@@ -8,8 +8,6 @@
 # Convenciones de comentarios:
 #   [INFRA] — especifico de la infra; reemplazar por la tuya.
 #   [DEFAULT] — valor por defecto recomendado (cambiar solo con razon).
-#   [PRE-P0 VALIDATED] — valor probado en el run mteb_hotpotqa_20260419_032905
-#       sobre nvidia/nemotron-3-nano; cambiar invalida la referencia.
 
 # =========================================================================
 # EMBEDDING (NIM)
@@ -36,7 +34,7 @@ LLM_MODEL_NAME=nvidia/nemotron-3-nano
 
 # ATENCION: los nombres exactos son NIM_MAX_CONCURRENT_REQUESTS y
 # NIM_REQUEST_TIMEOUT (no NIM_MAX_CONCURRENT ni NIM_TIMEOUT).
-NIM_MAX_CONCURRENT_REQUESTS=32  # [PRE-P0 VALIDATED]
+NIM_MAX_CONCURRENT_REQUESTS=32  # [DEFAULT]
 NIM_REQUEST_TIMEOUT=120         # [DEFAULT]
 NIM_MAX_RETRIES=3               # [DEFAULT]
 
@@ -179,15 +177,12 @@ KG_CHUNK_KEYWORDS_TOP_K=20
 # Fallback al contexto estructurado ante error/vacio/timeout.
 KG_SYNTHESIS_ENABLED=true  # [DEFAULT]
 
-# [PRE-P0 VALIDATED] Limite de output de la synthesis en caracteres.
-# 0 = usar el mismo limite que la generacion. 50000 cerro fallback_rate
-# al 2.86% en runs Pre-P0 (ver CLAUDE.md, seccion observabilidad).
+# [DEFAULT] Limite de output de la synthesis en caracteres.
+# 0 = usar el mismo limite que la generacion.
 KG_SYNTHESIS_MAX_CHARS=50000
 
-# [PRE-P0 VALIDATED] Timeout de la llamada de synthesis. Si se supera,
-# fallback al contexto estructurado. 180s cubre el p95_llm (~114s) +
-# queue p95 (~39s) con NIM_MAX_CONCURRENT_REQUESTS=32. Verificar
-# post-run con:
+# [DEFAULT] Timeout de la llamada de synthesis. Si se supera,
+# fallback al contexto estructurado. Verificar post-run con:
 #   jq '.config_snapshot._runtime.kg_synthesis_stats.fallback_rate'
 KG_SYNTHESIS_TIMEOUT_S=180
 


### PR DESCRIPTION
## Summary

- Registrar el run SIMPLE_VECTOR P0 (`mteb_hotpotqa_20260507_095501`) en `CLAUDE.md` bajo "P0 FASE ACTUAL", como tabla factual sin interpretar metricas.
- Purgar referencias al run anterior `mteb_hotpotqa_20260419_032905` y la tag `[PRE-P0 VALIDATED]` de `env.example` (cabecera + 3 sites). Reemplazada por `[DEFAULT]`.
- Reformular el bloque "Config validada" en `CLAUDE.md` a "Config recomendada" (la tag a la que apuntaba ya no existe).

Sin cambios funcionales. Doc-only.

## Test plan
- [x] `pytest tests/ -m "not integration"` → 448 passed, 7 skipped.
- [ ] Pendiente run gemelo `LIGHT_RAG` para que el bloque P0 sea comparable A/B (acción del usuario, no de claude_code).

https://claude.ai/code/session_01XNfaKEkdWXd79PXe5vYaq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNfaKEkdWXd79PXe5vYaq7)_