### PR TITLE
perf(gleaning): paralelizar via asyncio.gather (×32 speedup esperado)

### DIFF
--- a/shared/retrieval/lightrag/retriever.py
+++ b/shared/retrieval/lightrag/retriever.py
@@ -23,6 +23,7 @@ Flujo:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import threading
@@ -284,21 +285,48 @@ class LightRAGRetriever(BaseRetriever):
 
         # Gleaning: re-extraccion opcional para capturar entidades perdidas
         # (no re-extrae high_level_keywords; ver KG_GLEANING_ROUNDS en .env).
+        # Paraleliza via asyncio.gather respetando el semaforo del LLM service,
+        # igual que extract_batch_async. Las mutaciones del KG (add_triplets,
+        # add_entity_metadata) quedan fuera de las coroutines para preservar
+        # thread-safety del igraph subyacente.
         if self._kg_gleaning_rounds > 0 and self._extractor:
+            extractor = self._extractor
+            batch_sz = extractor._batch_size
+
+            async def _glean_one(
+                doc: Dict[str, Any],
+            ) -> Tuple[str, List[Any], List[KGRelation]]:
+                doc_id = doc.get("doc_id", "")
+                text = doc.get("content", "")
+                prev_entities = extraction_results.get(doc_id, ([], [], []))[0]
+                if not prev_entities:
+                    return doc_id, [], []
+                new_entities, new_relations = await extractor.glean_from_doc_async(
+                    doc_id, text, prev_entities,
+                )
+                return doc_id, new_entities, new_relations
+
+            async def _run_round() -> List[Any]:
+                collected: List[Any] = []
+                for start in range(0, len(documents), batch_sz):
+                    chunk = documents[start:start + batch_sz]
+                    tasks = [_glean_one(doc) for doc in chunk]
+                    chunk_results = await asyncio.gather(
+                        *tasks, return_exceptions=True
+                    )
+                    collected.extend(chunk_results)
+                return collected
+
             for gleaning_round in range(self._kg_gleaning_rounds):
                 t_glean = time.perf_counter()
                 gleaning_count = 0
-                for doc in documents:
-                    doc_id = doc.get("doc_id", "")
-                    text = doc.get("content", "")
-                    prev_entities = extraction_results.get(doc_id, ([], [], []))[0]
-                    if not prev_entities:
+                round_results = run_sync(_run_round())
+                for r in round_results:
+                    if isinstance(r, BaseException):
+                        logger.debug(f"Gleaning task exception: {r}")
+                        record_operational_event("gleaning_error")
                         continue
-                    new_entities, new_relations = run_sync(
-                        self._extractor.glean_from_doc_async(
-                            doc_id, text, prev_entities,
-                        )
-                    )
+                    doc_id, new_entities, new_relations = r
                     if new_relations:
                         added = self._kg.add_triplets(doc_id, new_relations)
                         total_triplets += added


### PR DESCRIPTION
## Summary

El bucle de gleaning en `LightRAGRetriever._build_knowledge_graph` ejecutaba `run_sync(glean_from_doc_async(...))` doc-a-doc sin `asyncio.gather`. Concurrencia efectiva = 1.

En el run `mteb_hotpotqa_20260510_172854` (40q × 800 docs, gleaning=1) eso dejaba la pasada de gleaning en **6h 32min** (29.5 s/doc secuencial) frente a los **35 min** de la extraccion inicial — 11× mas lento por la misma operacion sobre el mismo LLM. Total del run: 7h 16min, 90% gleaning.

## Cambio

`shared/retrieval/lightrag/retriever.py` (+38 / −10): refactor del bucle de gleaning para usar el mismo patron que `extract_batch_async`:

- Coroutine `_glean_one(doc)` por documento
- Chunks de `extractor._batch_size` con `asyncio.gather(*tasks, return_exceptions=True)`
- Mutaciones del KG (`add_triplets`, `add_entity_metadata`) post-`gather`, fuera de las coroutines (igraph thread-safety)
- `operational_stats.gleaning_error` preservado via `record_operational_event` sobre exceptions devueltas por gather

## Impacto esperado en el proximo run

- Pasada de gleaning: **6h 32min → ~12-15 min** (suelo ≈ latencia individual de cada call, ahora con concurrencia=32 efectiva)
- Total run @ 40×800: **7h 16min → ~50 min**
- Sin cambio en: numero de tripletas, prompts, retries, formato de log, contadores observables

## Test plan

- [x] `pytest tests/ -m "not integration"` → 448 passed, 7 skipped (baseline intacto)
- [x] Tests directos relevantes: `test_gleaning.py`, `test_lightrag_fusion.py`, `test_triplet_extractor.py`, `test_operational_tracker.py`, `test_get_retriever_factory.py`, `test_chunk_keywords_retrieval.py` → 104 passed
- [x] Sintaxis Python validada
- [ ] Verificacion end-to-end requiere acceso a NIM (claude_code no tiene). Validar en el proximo run real:
  - `gleaning round 1 en <X>ms` en console log: debe caer ~1-2 ordenes de magnitud vs los 23 574 234 ms del run de referencia
  - `num_relations` final en el mismo orden (~17K) — si baja, race condition en `add_triplets` (no deberia, esta post-gather)
  - `operational_stats.gleaning_error` ≈ 0

## Fuera de scope (no tocado)

- Warning de estimacion de tiempo en `evaluator.py` (sigue mintiendo factor ×432 si gleaning>0)
- `KG_CACHE_DIR` desactivado por defecto en el `.env`
- 80 warnings "empty content after stripping reasoning tags" (ortogonales a paralelizacion)
- Test unitario para el bucle de gleaning paralelizado (gap pre-existente del retriever-build path)

https://claude.ai/code/session_019KDM4uGUMURsJ6yXb4YmVk

---
_Generated by [Claude Code](https://claude.ai/code/session_019KDM4uGUMURsJ6yXb4YmVk)_