### PR TITLE
feat(observability): tracker per-fase de invocaciones LLM

### DIFF
--- a/sandbox_mteb/evaluator.py
+++ b/sandbox_mteb/evaluator.py
@@ -36,6 +36,7 @@ from shared.metrics import (
     max_judge_default_return_rate,
     reset_judge_fallback_stats,
 )
+from shared.llm import reset_llm_invocation_stats
 from shared.operational_tracker import reset_operational_stats
 from shared.retrieval import get_retriever, RetrievalStrategy
 from shared.retrieval.core import BaseRetriever
@@ -109,6 +110,9 @@ class MTEBEvaluator:
         # Reset del tracker de eventos operacionales (operational_stats):
         # contadores de degradaciones silenciosas en 7 puntos del pipeline.
         reset_operational_stats()
+        # Reset del tracker de invocaciones LLM (llm_invocation_stats):
+        # timing per-fase queue_ms / llm_ms para diagnostico de saturacion.
+        reset_llm_invocation_stats()
 
         try:
             self._init_components()

--- a/sandbox_mteb/generation_executor.py
+++ b/sandbox_mteb/generation_executor.py
@@ -466,7 +466,8 @@ class GenerationExecutor:
 
         try:
             response = await self._llm_service.invoke_async(
-                user_prompt, system_prompt=prompts["system"]
+                user_prompt, system_prompt=prompts["system"],
+                phase="generation",
             )
             return GenerationResult(
                 generated_response=str(response).strip(),
@@ -531,6 +532,7 @@ class GenerationExecutor:
                     user_prompt,
                     system_prompt=system_prompt,
                     timing_out=timing_out,
+                    phase="kg_synthesis",
                 ),
                 timeout=self._kg_synthesis_timeout_s,
             )

--- a/sandbox_mteb/result_builder.py
+++ b/sandbox_mteb/result_builder.py
@@ -14,6 +14,7 @@ from shared.types import (
     QueryEvaluationResult,
     LoadedDataset,
 )
+from shared.llm import LLMPhaseStats, get_llm_invocation_stats
 from shared.metrics import JudgeMetricStats, get_judge_fallback_stats
 from shared.operational_tracker import OperationalStats, get_operational_stats
 from shared.retrieval import RetrievalStrategy
@@ -52,6 +53,7 @@ class RuntimeSnapshot(TypedDict):
     judge_fallback_stats: Dict[str, JudgeMetricStats]
     kg_synthesis_stats: KGSynthesisStats
     operational_stats: OperationalStats
+    llm_invocation_stats: Dict[str, LLMPhaseStats]
 
 
 def _serialize_config(config: MTEBConfig) -> Dict[str, Any]:
@@ -193,6 +195,10 @@ def build_run(
         # generation). Valores altos => degradacion del canal aunque el
         # run termine sin error fatal.
         "operational_stats": get_operational_stats(),
+        # llm_invocation_stats: timing per-fase de invocaciones LLM
+        # (queue_ms vs llm_ms). Permite diagnosticar saturacion: cola
+        # alta => subir concurrencia; llm_ms alto => modelo no escala.
+        "llm_invocation_stats": get_llm_invocation_stats(),
     }
     config_snapshot["_runtime"] = runtime_snapshot
 

--- a/shared/llm.py
+++ b/shared/llm.py
@@ -32,8 +32,9 @@ import logging
 import re
 import threading
 import time
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Coroutine, Dict, Optional, TypedDict, TypeVar
+from typing import Any, Coroutine, Dict, List, Optional, TypedDict, TypeVar
 
 
 class InvokeTiming(TypedDict, total=False):
@@ -209,6 +210,116 @@ def run_sync(coro: Coroutine[Any, Any, _T]) -> _T:
     "bound to a different event loop".
     """
     return _persistent_loop.run(coro)  # type: ignore[no-any-return]
+
+
+class LLMPhaseStats(TypedDict, total=False):
+    """Stats per fase del pipeline en `_LLMInvocationTracker.snapshot()`.
+
+    Los samples de timing pueden ser menos que `invocations` cuando una
+    invocacion cayo antes de poblar la clave correspondiente
+    (cancelacion mid-call, timeout antes de acquire, etc.).
+    """
+
+    invocations: int
+    n_queue_samples: int
+    p50_queue_ms: float
+    p95_queue_ms: float
+    max_queue_ms: float
+    n_llm_samples: int
+    p50_llm_ms: float
+    p95_llm_ms: float
+    max_llm_ms: float
+
+
+def _percentile(values: List[float], p: float) -> float:
+    """Percentile inclusivo indexado a la baja. Devuelve 0.0 si vacio."""
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    idx = min(len(sorted_vals) - 1, int(p * len(sorted_vals)))
+    return sorted_vals[idx]
+
+
+class _LLMInvocationTracker:
+    """Contador + timing per-fase de invocaciones a `AsyncLLMService.invoke_async`.
+
+    Diagnostica saturacion del pipeline a nivel LLM: por cada `phase`
+    (extraction, gleaning, kg_synthesis, generation, query_keywords,
+    judge, ...) acumula listas paralelas de `queue_ms` (espera al
+    semaforo) y `llm_ms` (llamada al servidor NIM tras acquire).
+
+    Permite separar cuello-de-botella de cola (`queue_ms` alto =>
+    concurrencia saturada, subir `nim_max_concurrent` o bajar paralelismo
+    del caller) de cuello-de-botella del modelo (`llm_ms` alto => NIM no
+    escala mas; bajar concurrencia o cambiar modelo).
+
+    `phase` se pasa via keyword en cada llamada. Llamadas que omiten el
+    keyword caen al bucket "unknown".
+
+    Thread-safe via lock; snapshot/reset son atomicos.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._invocations: Counter = Counter()
+        self._queue_ms: Dict[str, List[float]] = defaultdict(list)
+        self._llm_ms: Dict[str, List[float]] = defaultdict(list)
+
+    def record(
+        self,
+        phase: str,
+        queue_ms: Optional[float],
+        llm_ms: Optional[float],
+    ) -> None:
+        """Registra una invocacion. `None` en queue_ms/llm_ms indica que
+        la metrica no se llego a poblar (cancelacion, timeout, etc.)."""
+        with self._lock:
+            self._invocations[phase] += 1
+            if queue_ms is not None:
+                self._queue_ms[phase].append(queue_ms)
+            if llm_ms is not None:
+                self._llm_ms[phase].append(llm_ms)
+
+    def snapshot(self) -> Dict[str, LLMPhaseStats]:
+        """Snapshot ordenado alfabeticamente por phase para diff estable
+        entre runs (jq, dashboards). Solo aparecen fases con >= 1
+        invocacion registrada."""
+        with self._lock:
+            result: Dict[str, LLMPhaseStats] = {}
+            for phase in sorted(self._invocations.keys()):
+                queue = self._queue_ms.get(phase, [])
+                llm = self._llm_ms.get(phase, [])
+                result[phase] = LLMPhaseStats(
+                    invocations=self._invocations[phase],
+                    n_queue_samples=len(queue),
+                    p50_queue_ms=round(_percentile(queue, 0.50), 1),
+                    p95_queue_ms=round(_percentile(queue, 0.95), 1),
+                    max_queue_ms=round(max(queue) if queue else 0.0, 1),
+                    n_llm_samples=len(llm),
+                    p50_llm_ms=round(_percentile(llm, 0.50), 1),
+                    p95_llm_ms=round(_percentile(llm, 0.95), 1),
+                    max_llm_ms=round(max(llm) if llm else 0.0, 1),
+                )
+            return result
+
+    def reset(self) -> None:
+        with self._lock:
+            self._invocations.clear()
+            self._queue_ms.clear()
+            self._llm_ms.clear()
+
+
+_llm_invocation_tracker = _LLMInvocationTracker()
+
+
+def get_llm_invocation_stats() -> Dict[str, LLMPhaseStats]:
+    """Snapshot per-fase de invocaciones LLM. Ver `_LLMInvocationTracker`."""
+    return _llm_invocation_tracker.snapshot()
+
+
+def reset_llm_invocation_stats() -> None:
+    """Reset del tracker; llamar al inicio de cada run."""
+    _llm_invocation_tracker.reset()
 
 
 class AsyncLLMService:
@@ -389,6 +500,7 @@ class AsyncLLMService:
         system_prompt: Optional[str] = None,
         max_tokens: int = 4096,
         timing_out: Optional[InvokeTiming] = None,
+        phase: str = "unknown",
     ) -> str:
         """API async principal.
 
@@ -396,14 +508,37 @@ class AsyncLLMService:
         `queue_wait_ms` y `llm_ms` del ultimo intento completado
         (ver `_invoke_with_retry` para semantica exacta bajo cancelaciones
         y reintentos).
+
+        `phase`: tag de la fase del pipeline (extraction, gleaning,
+        kg_synthesis, generation, query_keywords, judge, ...). Se
+        registra en `_llm_invocation_tracker` para diagnostico de
+        saturacion per-fase (cola del semaforo vs servidor NIM). Las
+        llamadas que omiten el keyword caen al bucket "unknown".
         """
         messages = []
         if system_prompt:
             messages.append(SystemMessage(content=system_prompt))
         messages.append(HumanMessage(content=prompt))
-        return await self._invoke_with_retry(
-            messages, max_tokens, timing_out=timing_out,
+
+        # Captura local del timing aun si el caller no pidio `timing_out`,
+        # para alimentar el tracker. Si paso su propio dict, lo usamos
+        # directamente (preservamos referencia y comportamiento previo).
+        effective_timing: InvokeTiming = (
+            timing_out if timing_out is not None else {}
         )
+        try:
+            return await self._invoke_with_retry(
+                messages, max_tokens, timing_out=effective_timing,
+            )
+        finally:
+            # Registrar siempre — en exito, fallo total, o cancelacion.
+            # `record()` acepta None en queue_ms/llm_ms cuando no se
+            # alcanzaron a poblar.
+            _llm_invocation_tracker.record(
+                phase=phase,
+                queue_ms=effective_timing.get("queue_wait_ms"),
+                llm_ms=effective_timing.get("llm_ms"),
+            )
 
     def invoke(
         self,

--- a/shared/metrics.py
+++ b/shared/metrics.py
@@ -582,7 +582,8 @@ async def _invoke_judge_async(
     _judge_fallback_tracker.record_invocation(metric_type)
     try:
         response = await llm_judge.invoke_async(
-            user_prompt, system_prompt=system_prompt
+            user_prompt, system_prompt=system_prompt,
+            phase="judge",
         )
         response_text = str(response).strip()
         return _parse_judge_result(response_text, metric_type)

--- a/shared/retrieval/lightrag/triplet_extractor.py
+++ b/shared/retrieval/lightrag/triplet_extractor.py
@@ -337,6 +337,7 @@ class TripletExtractor:
                 prompt,
                 system_prompt=TRIPLET_EXTRACTION_SYSTEM,
                 max_tokens=self._extraction_max_tokens,
+                phase="extraction",
             )
             entities, relations, chunk_keywords = self._parse_extraction_json(raw, doc_id)
             self._stats["docs_success"] += 1
@@ -390,6 +391,7 @@ class TripletExtractor:
                 prompt,
                 system_prompt=TRIPLET_EXTRACTION_SYSTEM,
                 max_tokens=self._extraction_max_tokens,
+                phase="gleaning",
             )
             entities, relations, _ = self._parse_extraction_json(raw, doc_id)
             return entities, relations
@@ -551,6 +553,7 @@ class TripletExtractor:
                 prompt,
                 system_prompt=TRIPLET_EXTRACTION_SYSTEM,
                 max_tokens=max_tokens,
+                phase="extraction",
             )
 
             batch_results = self._parse_batch_extraction_json(raw, non_empty)
@@ -748,6 +751,7 @@ class TripletExtractor:
                 prompt,
                 system_prompt=QUERY_KEYWORDS_SYSTEM,
                 max_tokens=self._keyword_max_tokens,
+                phase="query_keywords",
             )
             return self._parse_keywords_json(raw)
         except Exception as e:

--- a/tests/test_llm_invocation_tracker.py
+++ b/tests/test_llm_invocation_tracker.py
@@ -1,0 +1,121 @@
+"""Tests del _LLMInvocationTracker (shared/llm.py).
+
+Cubre: record per-fase, agregacion de percentiles, manejo de None,
+ordenacion alfabetica del snapshot, reset, aislamiento entre fases.
+Tests del singleton module-level (acceso via la API publica
+get_llm_invocation_stats / reset_llm_invocation_stats).
+"""
+
+from __future__ import annotations
+
+from shared.llm import (
+    _LLMInvocationTracker,
+    _llm_invocation_tracker,
+    _percentile,
+    get_llm_invocation_stats,
+    reset_llm_invocation_stats,
+)
+
+
+def test_percentile_empty() -> None:
+    assert _percentile([], 0.5) == 0.0
+
+
+def test_percentile_single_value() -> None:
+    assert _percentile([42.0], 0.5) == 42.0
+    assert _percentile([42.0], 0.95) == 42.0
+
+
+def test_percentile_ordering() -> None:
+    vals = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0]
+    p50 = _percentile(vals, 0.50)
+    p95 = _percentile(vals, 0.95)
+    assert p50 == 60.0  # index 5
+    assert p95 == 100.0  # index 9 (clamped)
+
+
+def test_record_increments_invocations() -> None:
+    t = _LLMInvocationTracker()
+    t.record("extraction", queue_ms=1.0, llm_ms=10.0)
+    t.record("extraction", queue_ms=2.0, llm_ms=20.0)
+    snap = t.snapshot()
+    assert snap["extraction"]["invocations"] == 2
+    assert snap["extraction"]["n_queue_samples"] == 2
+    assert snap["extraction"]["n_llm_samples"] == 2
+
+
+def test_record_none_skips_timing_but_counts_invocation() -> None:
+    t = _LLMInvocationTracker()
+    t.record("gleaning", queue_ms=None, llm_ms=None)
+    t.record("gleaning", queue_ms=5.0, llm_ms=None)
+    snap = t.snapshot()
+    assert snap["gleaning"]["invocations"] == 2
+    assert snap["gleaning"]["n_queue_samples"] == 1
+    assert snap["gleaning"]["n_llm_samples"] == 0
+
+
+def test_snapshot_percentiles() -> None:
+    t = _LLMInvocationTracker()
+    for v in [10.0, 20.0, 30.0, 40.0, 50.0]:
+        t.record("extraction", queue_ms=v, llm_ms=v * 10)
+    snap = t.snapshot()
+    e = snap["extraction"]
+    assert e["invocations"] == 5
+    assert e["p50_queue_ms"] == 30.0
+    assert e["max_queue_ms"] == 50.0
+    assert e["p50_llm_ms"] == 300.0
+    assert e["max_llm_ms"] == 500.0
+
+
+def test_phases_isolated() -> None:
+    t = _LLMInvocationTracker()
+    t.record("extraction", queue_ms=1.0, llm_ms=100.0)
+    t.record("gleaning", queue_ms=50.0, llm_ms=500.0)
+    snap = t.snapshot()
+    assert snap["extraction"]["p50_queue_ms"] == 1.0
+    assert snap["extraction"]["p50_llm_ms"] == 100.0
+    assert snap["gleaning"]["p50_queue_ms"] == 50.0
+    assert snap["gleaning"]["p50_llm_ms"] == 500.0
+
+
+def test_snapshot_sorted_phases() -> None:
+    t = _LLMInvocationTracker()
+    t.record("kg_synthesis", queue_ms=1.0, llm_ms=1.0)
+    t.record("generation", queue_ms=1.0, llm_ms=1.0)
+    t.record("extraction", queue_ms=1.0, llm_ms=1.0)
+    snap = t.snapshot()
+    assert list(snap.keys()) == ["extraction", "generation", "kg_synthesis"]
+
+
+def test_snapshot_empty_when_no_records() -> None:
+    t = _LLMInvocationTracker()
+    assert t.snapshot() == {}
+
+
+def test_reset_clears_state() -> None:
+    t = _LLMInvocationTracker()
+    t.record("extraction", queue_ms=1.0, llm_ms=10.0)
+    assert "extraction" in t.snapshot()
+    t.reset()
+    assert t.snapshot() == {}
+
+
+def test_unknown_bucket_used_when_phase_omitted() -> None:
+    # AsyncLLMService.invoke_async defaults to phase="unknown".
+    # Aqui simulamos llamando al tracker directamente con ese tag.
+    t = _LLMInvocationTracker()
+    t.record("unknown", queue_ms=2.0, llm_ms=20.0)
+    snap = t.snapshot()
+    assert snap["unknown"]["invocations"] == 1
+
+
+def test_module_singleton_record_and_snapshot() -> None:
+    # Verifica que la API publica (get_/reset_) opera sobre el mismo
+    # tracker que la registracion implicita desde invoke_async.
+    reset_llm_invocation_stats()
+    assert get_llm_invocation_stats() == {}
+    _llm_invocation_tracker.record("extraction", queue_ms=1.0, llm_ms=10.0)
+    snap = get_llm_invocation_stats()
+    assert snap["extraction"]["invocations"] == 1
+    reset_llm_invocation_stats()
+    assert get_llm_invocation_stats() == {}

--- a/tests/test_metrics_reference_based.py
+++ b/tests/test_metrics_reference_based.py
@@ -174,7 +174,9 @@ class _MockJudge:
         self.call_count += 1
         return '{"score": 0.8, "justification": "test"}'
 
-    async def invoke_async(self, user_prompt, system_prompt=None):
+    async def invoke_async(self, user_prompt, system_prompt=None, **kwargs):
+        # Acepta kwargs adicionales (phase, timing_out, max_tokens, ...)
+        # introducidos por la firma de AsyncLLMService.invoke_async.
         self.captured_prompt = user_prompt
         self.call_count += 1
         return '{"score": 0.8, "justification": "test"}'


### PR DESCRIPTION
## Summary

Anade `_LLMInvocationTracker` en `shared/llm.py` que registra `queue_ms` y `llm_ms` por cada llamada a `AsyncLLMService.invoke_async`, discriminado por fase del pipeline. Permite diagnosticar saturacion per-fase (cola del semaforo vs servidor NIM) durante cualquier punto del run — hoy solo `kg_synthesis_stats` lo mide, y solo durante synthesis.

## Motivacion

Tras paralelizar el gleaning en PR #71, la pasada bajo de 6h32min a 68min (×5.7) en el run `mteb_hotpotqa_20260511_103950`. Pero el techo teorico era ×32 (`nim_max_concurrent=32`); la concurrencia efectiva real esta alrededor de ×3-5. Sin datos per-fase de `queue_ms` vs `llm_ms` durante la indexacion, no se puede distinguir:

- `queue_ms` alto / `llm_ms` bajo → semaforo saturado, subir concurrencia
- `queue_ms` bajo / `llm_ms` alto → NIM no escala con thinking-mode concurrente, bajar concurrencia o cambiar modelo

## Cambios

| Archivo | Cambio |
|---|---|
| `shared/llm.py` | +141 lineas: `_LLMInvocationTracker` class, `LLMPhaseStats` TypedDict, `_percentile` helper, singleton + `get_llm_invocation_stats()` / `reset_llm_invocation_stats()`. `invoke_async` acepta `phase: str = "unknown"` y registra en `finally`. |
| `shared/retrieval/lightrag/triplet_extractor.py` | 4 sites tagged: `extraction` (x2), `gleaning`, `query_keywords`. |
| `sandbox_mteb/generation_executor.py` | 2 sites tagged: `generation`, `kg_synthesis`. |
| `shared/metrics.py` | 1 site tagged: `judge`. |
| `sandbox_mteb/result_builder.py` | `llm_invocation_stats` en `RuntimeSnapshot`. |
| `sandbox_mteb/evaluator.py` | `reset_llm_invocation_stats()` al inicio del run. |
| `tests/test_llm_invocation_tracker.py` | NUEVO, 12 tests. |
| `tests/test_metrics_reference_based.py` | Mock judge acepta `**kwargs`. |

Total: 281 inserciones, 6 borrados, 8 archivos.

## Estructura del nuevo observable

En `config_snapshot._runtime.llm_invocation_stats`, una entrada por fase:

```json
{
  "extraction": {
    "invocations": 800,
    "n_queue_samples": 800,
    "p50_queue_ms": 12.4,
    "p95_queue_ms": 540.1,
    "max_queue_ms": 891.2,
    "n_llm_samples": 800,
    "p50_llm_ms": 2871.0,
    "p95_llm_ms": 9012.5,
    "max_llm_ms": 12340.0
  },
  "gleaning": { ... },
  "kg_synthesis": { ... },
  "generation": { ... },
  "query_keywords": { ... },
  "judge": { ... }
}
```

## Test plan

- [x] `pytest tests/ -m "not integration"` → 460 passed (448 base + 12 nuevos), 7 skipped
- [x] Tests del tracker cubren: record + invocations, None en timing, percentiles, aislamiento per-fase, ordenacion del snapshot, reset, bucket `unknown`, singleton module-level
- [x] Mock judge actualizado para tolerar `**kwargs` (nuevo `phase` kwarg)
- [ ] Verificacion empirica end-to-end requiere run real con NIM (claude_code no tiene). Lectura esperada:
  - `extraction.p50_queue_ms` ≈ 0 al inicio del run (sin contention)
  - `gleaning.p50_queue_ms` vs `gleaning.p50_llm_ms` revela donde esta el cuello tras la paralelizacion de PR #71

## Fuera de scope

- Guardrails automaticos sobre `llm_invocation_stats` (analogos a `judge_fallback_threshold`). Pendiente cuando haya datos para calibrar umbrales.
- Unificacion con `_KGSynthesisTracker` (que tambien mide queue/llm timing pero solo para synthesis). Coexisten — el tracker general es ortogonal, no sustituto.
- Warning de estimacion de tiempo en `evaluator.py` (factor ×432 conocido cuando `gleaning>0`).

https://claude.ai/code/session_019KDM4uGUMURsJ6yXb4YmVk

---
_Generated by [Claude Code](https://claude.ai/code/session_019KDM4uGUMURsJ6yXb4YmVk)_